### PR TITLE
feat(frontend): display version tag in Header from package.json

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -16,7 +16,6 @@ import { Button, Select, Space, Tag, Tooltip } from 'antd'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { version } from '../../package.json'
 import type { Project } from '../types'
 
 interface HeaderProps {
@@ -114,7 +113,7 @@ const Header: React.FC<HeaderProps> = ({
         )}
       </Space>
       <Space>
-        <Tag style={{ fontSize: 11, lineHeight: '16px', padding: '0 4px' }}>v{version}</Tag>
+        <Tag style={{ fontSize: 11, lineHeight: '16px', padding: '0 4px' }}>v{__APP_VERSION__}</Tag>
         <Tooltip title={isDark ? t('switchToLightMode') : t('switchToDarkMode')}>
           <Button
             type="text"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -16,6 +16,7 @@ import { Button, Select, Space, Tag, Tooltip } from 'antd'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { version } from '../../package.json'
 import type { Project } from '../types'
 
 interface HeaderProps {
@@ -113,6 +114,7 @@ const Header: React.FC<HeaderProps> = ({
         )}
       </Space>
       <Space>
+        <Tag style={{ fontSize: 11, lineHeight: '16px', padding: '0 4px' }}>v{version}</Tag>
         <Tooltip title={isDark ? t('switchToLightMode') : t('switchToDarkMode')}>
           <Button
             type="text"

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? 'unknown'),
   },
   plugins: [react()],
   server: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
+  },
   plugins: [react()],
   server: {
     port: 5173,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+declare const process: {
+  env: {
+    npm_package_version?: string
+  }
+}
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0-dev'),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? 'unknown'),
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0-dev'),
   },
   plugins: [react()],
   server: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-declare const process: {
-  env: {
-    npm_package_version?: string
-  }
-}
+const npmPackageVersion = (
+  globalThis as { process?: { env?: { npm_package_version?: string } } }
+).process?.env?.npm_package_version
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0-dev'),
+    __APP_VERSION__: JSON.stringify(npmPackageVersion ?? '0.0.0-dev'),
   },
   plugins: [react()],
   server: {


### PR DESCRIPTION
## Summary

Display a small version tag next to the controls in the Header, auto-synced from `frontend/package.json`.

## Changes

- Import `version` from `../../package.json` — updating the version number now automatically reflects in the UI
- Add a `<Tag>` component showing `v2.1.0` (small, subtle, sits alongside the theme/language/project buttons)

## Screenshot

The Header now shows: `☰ ALA ● Connected v2.1.0 ☀ EN 📁 ⊞`

## Checks

- TypeScript compilation passes ✅
- Prettier format check passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The header now displays the application version as a compact tag near the right-side controls for quick release identification.
* **Chores**
  * Build now embeds the app version so the displayed tag reflects the packaged release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagawagao/ala/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->