### PR TITLE
fix: use .gitignore-based exclusion instead of hardcoded file-type whitelist

### DIFF
--- a/backend/src/ala/services/code_scanner.py
+++ b/backend/src/ala/services/code_scanner.py
@@ -198,12 +198,16 @@ def _load_gitignore_patterns(project_root: Path) -> list[str]:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
+        # Strip trailing slash (gitignore directory marker) so patterns
+        # like "dist/" generate "**/dist" and "**/dist/**" — covering files
+        # inside excluded directories, not just the directory entry itself.
+        line = line.rstrip("/")
         # Convert gitignore patterns to glob-style
         if line.startswith("/"):
             patterns.append(line[1:])
         else:
             patterns.append(f"**/{line}")
-        if not line.endswith("/") and not line.endswith("*"):
+        if not line.endswith("*"):
             patterns.append(f"**/{line}/**")
     return patterns
 

--- a/backend/src/ala/services/code_scanner.py
+++ b/backend/src/ala/services/code_scanner.py
@@ -202,13 +202,19 @@ def _load_gitignore_patterns(project_root: Path) -> list[str]:
         # like "dist/" generate "**/dist" and "**/dist/**" — covering files
         # inside excluded directories, not just the directory entry itself.
         line = line.rstrip("/")
-        # Convert gitignore patterns to glob-style
-        if line.startswith("/"):
-            patterns.append(line[1:])
-        else:
+        # Convert gitignore patterns to glob-style.
+        # Root-anchored patterns (starting with "/") only match at repo root —
+        # emit root-relative patterns without the "**/" prefix.
+        root_anchored = line.startswith("/")
+        if root_anchored:
+            line = line[1:]
+        if not root_anchored:
             patterns.append(f"**/{line}")
+        patterns.append(line)
         if not line.endswith("*"):
-            patterns.append(f"**/{line}/**")
+            patterns.append(f"{line}/**")
+            if not root_anchored:
+                patterns.append(f"**/{line}/**")
     return patterns
 
 

--- a/backend/src/ala/services/code_scanner.py
+++ b/backend/src/ala/services/code_scanner.py
@@ -178,6 +178,16 @@ def _matches_any(path: str, patterns: list[str]) -> bool:
     return False
 
 
+# Sentinel patterns that mean "include everything" — skip --glob so rg uses
+# its native file discovery (respects .gitignore, skips binaries/hidden files).
+_UNRESTRICTED_PATTERNS: frozenset[str] = frozenset({"**/*", "**", "*"})
+
+
+def _is_unrestricted(patterns: list[str]) -> bool:
+    """Return True if the patterns mean 'search everything'."""
+    return not patterns or all(p in _UNRESTRICTED_PATTERNS for p in patterns)
+
+
 def _load_gitignore_patterns(project_root: Path) -> list[str]:
     """Load patterns from .gitignore if it exists."""
     gitignore = project_root / ".gitignore"
@@ -284,8 +294,10 @@ class CodeScanner:
                 if _matches_any(rel_path, all_exclude):
                     continue
 
-                # Check include
-                if not _matches_any(rel_path, include_patterns):
+                # Check include (skip when unrestricted)
+                if not _is_unrestricted(include_patterns) and not _matches_any(
+                    rel_path, include_patterns
+                ):
                     continue
 
                 try:
@@ -462,9 +474,10 @@ class CodeScanner:
         else:
             return SearchResult()
 
-        # Include patterns → --glob
-        for g in self._rg_glob_to_patterns(include_patterns):
-            cmd.extend(["--glob", g])
+        # Include patterns → --glob (skip when unrestricted — let rg discover files natively)
+        if not _is_unrestricted(include_patterns):
+            for g in self._rg_glob_to_patterns(include_patterns):
+                cmd.extend(["--glob", g])
 
         # Exclude patterns → --glob '!...'
         for g in self._rg_glob_to_patterns(exclude_patterns):

--- a/backend/src/ala/services/project_manager.py
+++ b/backend/src/ala/services/project_manager.py
@@ -54,6 +54,11 @@ class ProjectManager:
         ).fetchall()
         include_patterns = [p["pattern"] for p in inc_rows]
 
+        # Normalize: old Android-only default → new unrestricted default
+        _LEGACY_DEFAULT = ["**/*.java", "**/*.kt", "**/*.xml"]
+        if include_patterns == _LEGACY_DEFAULT:
+            include_patterns = ["**/*"]
+
         # Load exclude patterns
         exc_rows = self._db.execute(
             "SELECT pattern FROM project_patterns WHERE project_id = ? AND type = 'exclude' ORDER BY ordering",
@@ -68,10 +73,10 @@ class ProjectManager:
             name=row["name"],
             paths=paths,
             include_patterns=include_patterns
-            if include_patterns is not None
+            if include_patterns
             else Project.__dataclass_fields__["include_patterns"].default_factory(),
             exclude_patterns=exclude_patterns
-            if exclude_patterns is not None
+            if exclude_patterns
             else Project.__dataclass_fields__["exclude_patterns"].default_factory(),
             filter_presets=filter_presets,
             created_at=row["created_at"],

--- a/backend/src/ala/services/project_manager.py
+++ b/backend/src/ala/services/project_manager.py
@@ -24,7 +24,7 @@ class Project:
     name: str
     paths: list[str]
     include_patterns: list[str] = field(
-        default_factory=lambda: ["**/*.java", "**/*.kt", "**/*.xml"]
+        default_factory=lambda: ["**/*"]
     )
     exclude_patterns: list[str] = field(
         default_factory=lambda: ["**/build/**", "**/node_modules/**", "**/.gradle/**", "**/.git/**"]

--- a/backend/src/ala/services/project_manager.py
+++ b/backend/src/ala/services/project_manager.py
@@ -31,6 +31,11 @@ class Project:
     created_at: str = field(default_factory=_utcnow)
 
 
+# Legacy Android-specific include patterns. Projects with this exact set are
+# auto-upgraded to ["**/*"] at load time (see _row_to_project).
+_LEGACY_ANDROID_PATTERNS = ["**/*.java", "**/*.kt", "**/*.xml"]
+
+
 class ProjectManager:
     def __init__(self, max_projects: int = 20, db=None, storage_path: Path | None = None):
         self._max_projects = max_projects
@@ -55,8 +60,7 @@ class ProjectManager:
         include_patterns = [p["pattern"] for p in inc_rows]
 
         # Normalize: old Android-only default → new unrestricted default
-        _LEGACY_DEFAULT = ["**/*.java", "**/*.kt", "**/*.xml"]
-        if include_patterns == _LEGACY_DEFAULT:
+        if include_patterns == _LEGACY_ANDROID_PATTERNS:
             include_patterns = ["**/*"]
 
         # Load exclude patterns

--- a/backend/src/ala/services/project_manager.py
+++ b/backend/src/ala/services/project_manager.py
@@ -23,9 +23,7 @@ class Project:
     id: str
     name: str
     paths: list[str]
-    include_patterns: list[str] = field(
-        default_factory=lambda: ["**/*"]
-    )
+    include_patterns: list[str] = field(default_factory=lambda: ["**/*"])
     exclude_patterns: list[str] = field(
         default_factory=lambda: ["**/build/**", "**/node_modules/**", "**/.gradle/**", "**/.git/**"]
     )


### PR DESCRIPTION
## Problem

Default `include_patterns` was hardcoded to `["**/*.java", "**/*.kt", "**/*.xml"]`, which meant ripgrep's `--glob` only searched Android file types. For projects without those extensions (e.g. ALA's own Python/TypeScript source), rg always returned empty — even for trivial patterns like `LAZY_LOG_TOOLS`.

## Fix

1. **Default `include_patterns` → `["**/*"]`** — no file-type whitelist
2. **Skip `--glob` in rg command when unrestricted** — rg natively respects `.gitignore`, skips binaries and hidden files
3. **Skip include filter in Python `list_files()` when unrestricted** — relies on `.gitignore` + manual `exclude_patterns`

This works for **any** project regardless of language or file types. Users can still set restrictive `include_patterns` for projects where they want to limit searches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code scanner now properly recognizes and handles unrestricted file patterns (such as `**/*`) without applying filtering restrictions.
  * Default file scanning behavior expanded to include all file types instead of Java, Kotlin, and XML files only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagawagao/ala/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->