### PR TITLE
feat: lazy log streaming — filter-on-demand backend

### DIFF
--- a/backend/src/ala/api/logs.py
+++ b/backend/src/ala/api/logs.py
@@ -2,8 +2,15 @@
 
 import json
 import logging
+import os
+import re
+import shutil
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -568,3 +575,377 @@ async def parse_file_stream(req: FileStreamRequest):
         media_type="application/x-ndjson",
         headers={"X-Accel-Buffering": "no"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Lazy Log Streaming: filter helpers, upload-to-temp, temp cleanup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompiledFilters:
+    """Pre-compiled filter matchers for efficient per-line evaluation."""
+
+    start_time: str | None = None
+    end_time: str | None = None
+    level: str | None = None
+    pid: str | None = None
+    tid: str | None = None
+    kw_regex: re.Pattern | None = None
+    kw_fallback: str | None = None
+    tag_regex: re.Pattern | None = None
+    tag_fallback: str | None = None
+    has_kw: bool = False
+    has_tag: bool = False
+    use_or: bool = False
+
+
+def _precompile_filters(filters: LogFilters) -> CompiledFilters:
+    """Pre-compile all filter conditions once, before line-by-line scanning."""
+    kw_regex = None
+    kw_fallback = None
+    if filters.keywords and filters.keywords.strip():
+        try:
+            kw_regex = re.compile(filters.keywords, re.IGNORECASE)
+        except re.error:
+            kw_fallback = filters.keywords.lower()
+
+    tag_regex = None
+    tag_fallback = None
+    if filters.tag and filters.tag.strip():
+        try:
+            tag_regex = re.compile(filters.tag, re.IGNORECASE)
+        except re.error:
+            tag_fallback = filters.tag.lower()
+
+    return CompiledFilters(
+        start_time=filters.start_time.strip() if filters.start_time and filters.start_time.strip() else None,
+        end_time=filters.end_time.strip() if filters.end_time and filters.end_time.strip() else None,
+        level=filters.level.strip()
+        if filters.level and filters.level.strip() and filters.level.strip() != "ALL"
+        else None,
+        pid=filters.pid.strip() if filters.pid and filters.pid.strip() else None,
+        tid=filters.tid.strip() if filters.tid and filters.tid.strip() else None,
+        kw_regex=kw_regex,
+        kw_fallback=kw_fallback,
+        tag_regex=tag_regex,
+        tag_fallback=tag_fallback,
+        has_kw=kw_regex is not None or kw_fallback is not None,
+        has_tag=tag_regex is not None or tag_fallback is not None,
+        use_or=filters.tag_keyword_relation == "OR",
+    )
+
+
+def _line_matches(entry: ServiceLogEntry, cf: CompiledFilters) -> bool:
+    """Check if a single LogEntry matches all compiled filter conditions."""
+    if cf.start_time or cf.end_time:
+        if not entry.timestamp:
+            return False
+        if cf.start_time and entry.timestamp < cf.start_time:
+            return False
+        if cf.end_time and entry.timestamp > cf.end_time:
+            return False
+
+    if cf.level and entry.level != cf.level:
+        return False
+
+    if cf.pid and entry.pid != cf.pid:
+        return False
+
+    if cf.tid and entry.tid != cf.tid:
+        return False
+
+    if cf.has_kw or cf.has_tag:
+        kw_match = True
+        if cf.has_kw:
+            if cf.kw_regex is not None:
+                kw_match = bool(
+                    cf.kw_regex.search(entry.message) or cf.kw_regex.search(entry.raw_line)
+                )
+            elif cf.kw_fallback is not None:
+                fb = cf.kw_fallback
+                kw_match = fb in entry.message.lower() or fb in entry.raw_line.lower()
+            else:
+                kw_match = True
+
+        tag_match = True
+        if cf.has_tag:
+            if cf.tag_regex is not None:
+                tag_match = bool(cf.tag_regex.search(entry.tag))
+            elif cf.tag_fallback is not None:
+                tag_match = cf.tag_fallback in entry.tag.lower()
+            else:
+                tag_match = True
+
+        if cf.use_or and cf.has_kw and cf.has_tag:
+            if not (kw_match or tag_match):
+                return False
+        else:
+            if not (kw_match and tag_match):
+                return False
+
+    return True
+
+
+def _accumulate_stats(
+    entry: ServiceLogEntry,
+    by_level: dict[str, int],
+    tags: dict[str, int],
+    pids: dict[str, int],
+) -> None:
+    """Accumulate statistics for a matching entry (inline, no intermediate list)."""
+    by_level[entry.level] = by_level.get(entry.level, 0) + 1
+    tags[entry.tag] = tags.get(entry.tag, 0) + 1
+    if entry.pid:
+        pids[entry.pid] = pids.get(entry.pid, 0) + 1
+
+
+def _get_temp_dir() -> Path:
+    """Return the temp log storage directory, creating it if needed."""
+    env_dir = os.environ.get("ALA_TEMP_DIR")
+    if env_dir:
+        temp_dir = Path(env_dir)
+    else:
+        temp_dir = Path.home() / ".ala" / "temp_logs"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    return temp_dir
+
+
+# ---- T1: POST /logs/filter/stream ----
+
+
+class FileFilterRequest(BaseModel):
+    """Request for POST /logs/filter/stream."""
+
+    path: str
+    filters: LogFilters
+
+
+@router.post("/filter/stream")
+async def filter_log_stream(req: FileFilterRequest, request: Request):
+    """Stream-parse a log file, apply filters line-by-line, and stream only matching entries."""
+    try:
+        validated = LogAnalyzer._validate_path(req.path)
+    except PathTraversalError as e:
+        raise HTTPException(status_code=400, detail=f"Path traversal rejected: {e}")
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    compiled = _precompile_filters(req.filters)
+
+    async def _generate():
+        matched = 0
+        scanned = 0
+        by_level: dict[str, int] = {}
+        tags: dict[str, int] = {}
+        pids: dict[str, int] = {}
+
+        try:
+            fmt = _analyzer.detect_log_format("")
+            sample_lines: list[str] = []
+            fh = _analyzer._open_log_path(validated)
+            try:
+                for raw_line in fh:
+                    stripped = raw_line.strip()
+                    if stripped and len(sample_lines) < 10:
+                        sample_lines.append(stripped)
+                    if len(sample_lines) >= 10:
+                        break
+            finally:
+                if hasattr(fh, "close"):
+                    fh.close()
+
+            if sample_lines:
+                fmt = _analyzer.detect_log_format("\n".join(sample_lines))
+
+            lower_path = validated.lower()
+            if lower_path.endswith(".zip") and not lower_path.endswith(".tar.gz"):
+                import io as io_mod
+                import zipfile as zf_mod
+
+                with zf_mod.ZipFile(validated, "r") as zf:
+                    for info in zf.infolist():
+                        if info.is_dir():
+                            continue
+                        if info.filename.lower().endswith("/"):
+                            continue
+                        source = info.filename
+                        with zf.open(info) as member_fh:
+                            wrapper = io_mod.TextIOWrapper(
+                                member_fh, encoding="utf-8", errors="replace"
+                            )
+                            line_num = 0
+                            for raw_line in wrapper:
+                                line_num += 1
+                                scanned += 1
+                                if scanned % 100 == 0 and await request.is_disconnected():
+                                    return
+                                raw = raw_line.rstrip("\n\r")
+                                if not raw.strip():
+                                    continue
+                                entry = _analyzer._parse_single_line(raw, line_num, fmt, source)
+                                if _line_matches(entry, compiled):
+                                    matched += 1
+                                    _accumulate_stats(entry, by_level, tags, pids)
+                                    line = _from_service_entry(entry)
+                                    yield json.dumps(line.model_dump()) + "\n"
+            else:
+                source = Path(validated).name
+                fh = _analyzer._open_log_path(validated)
+                try:
+                    line_num = 0
+                    for raw_line in fh:
+                        line_num += 1
+                        scanned += 1
+                        if scanned % 100 == 0 and await request.is_disconnected():
+                            return
+                        raw = raw_line.rstrip("\n\r")
+                        if not raw.strip():
+                            continue
+                        entry = _analyzer._parse_single_line(raw, line_num, fmt, source)
+                        if _line_matches(entry, compiled):
+                            matched += 1
+                            _accumulate_stats(entry, by_level, tags, pids)
+                            line = _from_service_entry(entry)
+                            yield json.dumps(line.model_dump()) + "\n"
+                finally:
+                    if hasattr(fh, "close"):
+                        fh.close()
+
+        except (ValueError, OSError) as exc:
+            yield json.dumps({"_error": str(exc)}) + "\n"
+            return
+
+        yield json.dumps(
+            {
+                "_done": True,
+                "matched": matched,
+                "scanned": scanned,
+                "stats": {
+                    "total": matched,
+                    "by_level": by_level,
+                    "tags": tags,
+                    "pids": pids,
+                },
+            }
+        ) + "\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="application/x-ndjson",
+        headers={"X-Accel-Buffering": "no"},
+    )
+
+
+# ---- T3: POST /logs/upload/temp ----
+
+
+class TempFileInfo(BaseModel):
+    original_name: str
+    saved_path: str
+    size_bytes: int
+    format_detected: str
+
+
+class TempUploadResponse(BaseModel):
+    session_uuid: str
+    files: list[TempFileInfo]
+
+
+@router.post("/upload/temp", response_model=TempUploadResponse)
+async def upload_to_temp(files: list[UploadFile] = File(...)):
+    """Save uploaded log files to a temp directory and return their paths."""
+    session_uuid = str(uuid.uuid4())
+    temp_root = _get_temp_dir()
+    session_dir = temp_root / session_uuid
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    saved: list[TempFileInfo] = []
+    for upload in files:
+        safe_name = Path(upload.filename or "log").name
+        dest_path = session_dir / safe_name
+
+        content = await upload.read()
+        with open(dest_path, "wb") as f:
+            f.write(content)
+
+        fmt = "unknown"
+        try:
+            with open(dest_path, "rb") as f:
+                sample = f.read(4096)
+            text_sample = sample.decode("utf-8", errors="replace")
+            fmt = _analyzer.detect_log_format(text_sample).value
+        except Exception:
+            pass
+
+        saved.append(
+            TempFileInfo(
+                original_name=safe_name,
+                saved_path=str(dest_path),
+                size_bytes=len(content),
+                format_detected=fmt,
+            )
+        )
+
+    return TempUploadResponse(session_uuid=session_uuid, files=saved)
+
+
+# ---- T6: Temp cleanup ----
+
+
+class TempStatusResponse(BaseModel):
+    dir_path: str
+    session_count: int
+    total_size_bytes: int
+
+
+@router.get("/temp/status", response_model=TempStatusResponse)
+async def temp_status():
+    """Return temp directory info: path, session count, total size."""
+    temp_dir = _get_temp_dir()
+    count = 0
+    total = 0
+    if temp_dir.exists():
+        for entry in temp_dir.iterdir():
+            if entry.is_dir():
+                count += 1
+                try:
+                    for f in entry.rglob("*"):
+                        if f.is_file():
+                            total += f.stat().st_size
+                except OSError:
+                    pass
+    return TempStatusResponse(
+        dir_path=str(temp_dir),
+        session_count=count,
+        total_size_bytes=total,
+    )
+
+
+@router.post("/temp/cleanup")
+async def temp_cleanup():
+    """Delete temp session directories older than the configured max age (default 24h)."""
+    max_age_hours = int(os.environ.get("ALA_TEMP_MAX_AGE_HOURS", "24"))
+    temp_dir = _get_temp_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    cleaned = 0
+
+    if not temp_dir.exists():
+        return {"cleaned": 0, "message": "Temp directory does not exist"}
+
+    for entry in temp_dir.iterdir():
+        if entry.is_dir():
+            try:
+                mtime = entry.stat().st_mtime
+                if mtime < cutoff:
+                    shutil.rmtree(entry)
+                    cleaned += 1
+                    logger.info("Cleaned up old temp session: %s", entry.name)
+            except OSError:
+                logger.warning("Failed to clean up temp dir: %s", entry)
+
+    return {"cleaned": cleaned, "message": f"Cleaned {cleaned} old session(s)"}

--- a/backend/src/ala/api/logs.py
+++ b/backend/src/ala/api/logs.py
@@ -619,8 +619,12 @@ def _precompile_filters(filters: LogFilters) -> CompiledFilters:
             tag_fallback = filters.tag.lower()
 
     return CompiledFilters(
-        start_time=filters.start_time.strip() if filters.start_time and filters.start_time.strip() else None,
-        end_time=filters.end_time.strip() if filters.end_time and filters.end_time.strip() else None,
+        start_time=filters.start_time.strip()
+        if filters.start_time and filters.start_time.strip()
+        else None,
+        end_time=filters.end_time.strip()
+        if filters.end_time and filters.end_time.strip()
+        else None,
         level=filters.level.strip()
         if filters.level and filters.level.strip() and filters.level.strip() != "ALL"
         else None,
@@ -767,18 +771,24 @@ async def filter_log_stream(req: FileFilterRequest, request: Request):
                 import io as io_mod
                 import zipfile as zf_mod
 
+                # File extensions treated as log text files (mirrors log_analyzer._LOG_TEXT_EXTS)
+                _log_text_exts = {".log", ".txt", ".logcat", ""}
+
                 with zf_mod.ZipFile(validated, "r") as zf:
+                    line_num = 0
                     for info in zf.infolist():
                         if info.is_dir():
                             continue
                         if info.filename.lower().endswith("/"):
+                            continue
+                        ext = os.path.splitext(info.filename.lower())[1]
+                        if ext not in _log_text_exts:
                             continue
                         source = info.filename
                         with zf.open(info) as member_fh:
                             wrapper = io_mod.TextIOWrapper(
                                 member_fh, encoding="utf-8", errors="replace"
                             )
-                            line_num = 0
                             for raw_line in wrapper:
                                 line_num += 1
                                 scanned += 1
@@ -820,19 +830,23 @@ async def filter_log_stream(req: FileFilterRequest, request: Request):
             yield json.dumps({"_error": str(exc)}) + "\n"
             return
 
-        yield json.dumps(
-            {
-                "_done": True,
-                "matched": matched,
-                "scanned": scanned,
-                "stats": {
+        yield (
+            json.dumps(
+                {
+                    "_done": True,
                     "total": matched,
-                    "by_level": by_level,
-                    "tags": tags,
-                    "pids": pids,
-                },
-            }
-        ) + "\n"
+                    "matched": matched,
+                    "scanned": scanned,
+                    "stats": {
+                        "total": matched,
+                        "by_level": by_level,
+                        "tags": tags,
+                        "pids": pids,
+                    },
+                }
+            )
+            + "\n"
+        )
 
     return StreamingResponse(
         _generate(),
@@ -868,10 +882,19 @@ async def upload_to_temp(files: list[UploadFile] = File(...)):
     for upload in files:
         safe_name = Path(upload.filename or "log").name
         dest_path = session_dir / safe_name
+        # Avoid overwriting duplicate uploads
+        counter = 1
+        stem, ext = os.path.splitext(safe_name)
+        while dest_path.exists():
+            dest_path = session_dir / f"{stem}_{counter}{ext}"
+            counter += 1
 
-        content = await upload.read()
+        # Stream chunks to disk instead of buffering entire file in memory
+        total_bytes = 0
         with open(dest_path, "wb") as f:
-            f.write(content)
+            while chunk := await upload.read(64 * 1024):
+                f.write(chunk)
+                total_bytes += len(chunk)
 
         fmt = "unknown"
         try:
@@ -886,7 +909,7 @@ async def upload_to_temp(files: list[UploadFile] = File(...)):
             TempFileInfo(
                 original_name=safe_name,
                 saved_path=str(dest_path),
-                size_bytes=len(content),
+                size_bytes=total_bytes,
                 format_detected=fmt,
             )
         )

--- a/backend/src/ala/main.py
+++ b/backend/src/ala/main.py
@@ -46,6 +46,31 @@ class _SPAStaticFiles(StaticFiles):
             raise
 
 
+def _cleanup_temp_on_startup() -> None:
+    """Delete temp log session directories older than 24 hours on startup."""
+    import os
+    import shutil
+    import time
+    from pathlib import Path
+
+    max_age_hours = int(os.environ.get("ALA_TEMP_MAX_AGE_HOURS", "24"))
+    env_dir = os.environ.get("ALA_TEMP_DIR")
+    temp_dir = Path(env_dir) if env_dir else Path.home() / ".ala" / "temp_logs"
+
+    if not temp_dir.exists():
+        return
+
+    cutoff = time.time() - (max_age_hours * 3600)
+    for entry in temp_dir.iterdir():
+        if entry.is_dir():
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    shutil.rmtree(entry)
+                    logger.info("Cleaned up old temp session on startup: %s", entry.name)
+            except OSError:
+                logger.warning("Failed to clean up temp dir on startup: %s", entry)
+
+
 def create_app() -> FastAPI:
     # Build one MCP HTTP sub-application per FastAPI app instance so repeated
     # TestClient create/teardown cycles can safely create fresh app instances.
@@ -61,6 +86,10 @@ def create_app() -> FastAPI:
         )
         # Trigger DB initialization and migration
         get_db()
+
+        # Clean up old temp log files on startup
+        _cleanup_temp_on_startup()
+
         # Start the FastMCP session-manager task-group alongside the FastAPI app.
         # The mcp_http_app lifespan initialises StreamableHTTPSessionManager.run()
         # which is required before any MCP request can be handled.

--- a/backend/src/ala/main.py
+++ b/backend/src/ala/main.py
@@ -53,7 +53,11 @@ def _cleanup_temp_on_startup() -> None:
     import time
     from pathlib import Path
 
-    max_age_hours = int(os.environ.get("ALA_TEMP_MAX_AGE_HOURS", "24"))
+    try:
+        max_age_hours = int(os.environ.get("ALA_TEMP_MAX_AGE_HOURS", "24"))
+    except (TypeError, ValueError):
+        logger.warning("ALA_TEMP_MAX_AGE_HOURS is invalid, falling back to 24")
+        max_age_hours = 24
     env_dir = os.environ.get("ALA_TEMP_DIR")
     temp_dir = Path(env_dir) if env_dir else Path.home() / ".ala" / "temp_logs"
 

--- a/backend/src/ala/services/log_analyzer.py
+++ b/backend/src/ala/services/log_analyzer.py
@@ -756,9 +756,10 @@ class LogAnalyzer:
             if has_kw or has_tag:
                 kw_match = True
                 if has_kw:
-                    text = f"{log.tag} {log.message}"
                     kw_match = bool(
-                        kw_regex.search(text) if kw_regex else kw_fallback in text.lower()
+                        (kw_regex.search(log.message) if kw_regex else kw_fallback in log.message.lower())
+                        or
+                        (kw_regex.search(log.raw_line) if kw_regex else kw_fallback in log.raw_line.lower())
                     )
 
                 tag_match = True

--- a/backend/src/ala/services/log_analyzer.py
+++ b/backend/src/ala/services/log_analyzer.py
@@ -757,9 +757,16 @@ class LogAnalyzer:
                 kw_match = True
                 if has_kw:
                     kw_match = bool(
-                        (kw_regex.search(log.message) if kw_regex else kw_fallback in log.message.lower())
-                        or
-                        (kw_regex.search(log.raw_line) if kw_regex else kw_fallback in log.raw_line.lower())
+                        (
+                            kw_regex.search(log.message)
+                            if kw_regex
+                            else kw_fallback in log.message.lower()
+                        )
+                        or (
+                            kw_regex.search(log.raw_line)
+                            if kw_regex
+                            else kw_fallback in log.raw_line.lower()
+                        )
                     )
 
                 tag_match = True

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -22,6 +22,27 @@ function isError(line: StreamLine): line is StreamError {
   return '_error' in line
 }
 
+/** Sentinel for POST /logs/filter/stream — includes stats. */
+export interface FilterStreamDone {
+  _done: true
+  matched: number
+  scanned: number
+  stats: LogStatistics
+}
+
+/** Response for POST /logs/upload/temp. */
+export interface TempFileInfo {
+  original_name: string
+  saved_path: string
+  size_bytes: number
+  format_detected: string
+}
+
+export interface TempUploadResponse {
+  session_uuid: string
+  files: TempFileInfo[]
+}
+
 /** Register a local log file for lazy AI-driven analysis (FEAT-LAZY-LOG). */
 export async function parseLocalPath(path: string): Promise<LocalFileRef> {
   return apiFetch<LocalFileRef>('/logs/parse-local', {
@@ -189,4 +210,44 @@ export async function* parseSelectedFilesStream(
     yield line as LogEntry | StreamDone
     if (isDone(line)) return
   }
+}
+
+/**
+ * Stream filtered log entries from a local file via the backend.
+ *
+ * Calls ``POST /api/logs/filter/stream`` and yields only matching
+ * ``LogEntry`` objects.  The final sentinel ``{_done, matched, scanned, stats}``
+ * is yielded at end of stream.
+ */
+export async function* streamFilteredLogs(
+  filePath: string,
+  filters: LogFilters,
+  signal?: AbortSignal,
+): AsyncGenerator<LogEntry | FilterStreamDone> {
+  type FilterLine =
+    | LogEntry
+    | { _done: true; matched: number; scanned: number; stats: LogStatistics }
+    | { _error: string }
+
+  for await (const line of streamNDJSON<FilterLine>(
+    '/logs/filter/stream',
+    { path: filePath, filters },
+    signal,
+  )) {
+    if ('_error' in line) {
+      throw new Error(line._error)
+    }
+    yield line as LogEntry | FilterStreamDone
+    if ('_done' in line) return
+  }
+}
+
+/**
+ * Upload log files to a temp directory on the server.
+ *
+ * Calls ``POST /api/logs/upload/temp`` and returns the session UUID
+ * and saved file paths that can be used with ``streamFilteredLogs``.
+ */
+export async function uploadToTemp(files: File[]): Promise<TempUploadResponse> {
+  return apiUploadMulti<TempUploadResponse>('/logs/upload/temp', files)
 }

--- a/frontend/src/hooks/useLazyLogStream.ts
+++ b/frontend/src/hooks/useLazyLogStream.ts
@@ -1,0 +1,165 @@
+import { useState, useCallback, useRef } from 'react'
+import type { LogEntry, LogFilters, LogStatistics } from '../types'
+import { streamFilteredLogs } from '../api/logs'
+import type { FilterStreamDone } from '../api/logs'
+
+export interface FilterProgress {
+  matched: number
+  scanned: number
+  total?: number
+}
+
+interface UseLazyLogStreamReturn {
+  displayLogs: LogEntry[]
+  loading: boolean
+  error: string | undefined
+  fileNames: string[]
+  formatDetected: string | undefined
+  filterProgress: FilterProgress | null
+  sourceRef: string | null
+  stats: LogStatistics | null
+  loadSource: (ref: string, labels: string[], lineCount?: number) => void
+  triggerFilter: (filters: LogFilters) => Promise<void>
+  abort: () => void
+  reset: () => void
+}
+
+const BATCH_SIZE = 500
+
+export function useLazyLogStream(): UseLazyLogStreamReturn {
+  const [displayLogs, setDisplayLogs] = useState<LogEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const [fileNames, setFileNames] = useState<string[]>([])
+  const [formatDetected, setFormatDetected] = useState<string | undefined>()
+  const [filterProgress, setFilterProgress] = useState<FilterProgress | null>(null)
+  const [sourceRef, setSourceRef] = useState<string | null>(null)
+  const [stats, setStats] = useState<LogStatistics | null>(null)
+  const [totalLines, setTotalLines] = useState<number | undefined>()
+
+  const abortRef = useRef<AbortController | null>(null)
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort()
+    abortRef.current = null
+  }, [])
+
+  const reset = useCallback(() => {
+    abort()
+    setDisplayLogs([])
+    setError(undefined)
+    setFileNames([])
+    setFormatDetected(undefined)
+    setFilterProgress(null)
+    setSourceRef(null)
+    setStats(null)
+    setTotalLines(undefined)
+    setLoading(false)
+  }, [abort])
+
+  const loadSource = useCallback(
+    (ref: string, labels: string[], lineCount?: number) => {
+      abort()
+      setSourceRef(ref)
+      setFileNames(labels)
+      setDisplayLogs([])
+      setStats(null)
+      setFilterProgress(null)
+      setError(undefined)
+      setFormatDetected(undefined)
+      setLoading(false)
+      if (lineCount !== undefined) {
+        setTotalLines(lineCount)
+      }
+    },
+    [abort],
+  )
+
+  const triggerFilter = useCallback(
+    async (filters: LogFilters) => {
+      if (!sourceRef) {
+        setError('No source file loaded')
+        return
+      }
+
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      setLoading(true)
+      setError(undefined)
+      setDisplayLogs([])
+      setFilterProgress({ matched: 0, scanned: 0, total: totalLines })
+
+      const buffer: LogEntry[] = []
+      let matchedCount = 0
+      let scannedCount = 0
+      let detectedFormat: string | undefined
+
+      const flush = () => {
+        if (buffer.length === 0) return
+        const toAdd = buffer.splice(0)
+        setDisplayLogs((prev) => [...prev, ...toAdd])
+      }
+
+      try {
+        const generator = streamFilteredLogs(sourceRef, filters, controller.signal)
+        for await (const line of generator) {
+          if (controller.signal.aborted) break
+
+          if ('_done' in line && line._done) {
+            const done = line as FilterStreamDone
+            matchedCount = done.matched
+            scannedCount = done.scanned
+            if (done.stats) {
+              setStats(done.stats)
+            }
+            break
+          }
+
+          const entry = line as LogEntry
+          buffer.push(entry)
+          matchedCount++
+
+          if (entry.source_file && !detectedFormat) {
+            detectedFormat = entry.source_file
+            setFormatDetected(entry.source_file)
+          }
+
+          if (buffer.length >= BATCH_SIZE) flush()
+        }
+        flush()
+
+        setFilterProgress({
+          matched: matchedCount,
+          scanned: scannedCount,
+          total: totalLines,
+        })
+      } catch (err: unknown) {
+        if ((err as Error).name === 'AbortError') return
+        const msg = err instanceof Error ? err.message : 'Filter stream error'
+        setError(msg)
+      } finally {
+        setLoading(false)
+      }
+
+      return
+    },
+    [sourceRef, totalLines],
+  )
+
+  return {
+    displayLogs,
+    loading,
+    error,
+    fileNames,
+    formatDetected,
+    filterProgress,
+    sourceRef,
+    stats,
+    loadSource,
+    triggerFilter,
+    abort,
+    reset,
+  }
+}

--- a/frontend/src/hooks/useLazyLogStream.ts
+++ b/frontend/src/hooks/useLazyLogStream.ts
@@ -38,6 +38,7 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
   const [totalLines, setTotalLines] = useState<number | undefined>()
 
   const abortRef = useRef<AbortController | null>(null)
+  const generationRef = useRef(0)
 
   const abort = useCallback(() => {
     abortRef.current?.abort()
@@ -70,6 +71,8 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
       setLoading(false)
       if (lineCount !== undefined) {
         setTotalLines(lineCount)
+      } else {
+        setTotalLines(undefined)
       }
     },
     [abort],
@@ -86,20 +89,24 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
       const controller = new AbortController()
       abortRef.current = controller
 
+      const gen = ++generationRef.current
+
       setLoading(true)
       setError(undefined)
       setDisplayLogs([])
+      setStats(null)
       setFilterProgress({ matched: 0, scanned: 0, total: totalLines })
 
       const buffer: LogEntry[] = []
       let matchedCount = 0
       let scannedCount = 0
-      let detectedFormat: string | undefined
 
       const flush = () => {
         if (buffer.length === 0) return
         const toAdd = buffer.splice(0)
-        setDisplayLogs((prev) => [...prev, ...toAdd])
+        if (generationRef.current === gen) {
+          setDisplayLogs((prev) => [...prev, ...toAdd])
+        }
       }
 
       try {
@@ -111,7 +118,7 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
             const done = line as FilterStreamDone
             matchedCount = done.matched
             scannedCount = done.scanned
-            if (done.stats) {
+            if (done.stats && generationRef.current === gen) {
               setStats(done.stats)
             }
             break
@@ -121,26 +128,27 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
           buffer.push(entry)
           matchedCount++
 
-          if (entry.source_file && !detectedFormat) {
-            detectedFormat = entry.source_file
-            setFormatDetected(entry.source_file)
-          }
-
           if (buffer.length >= BATCH_SIZE) flush()
         }
         flush()
 
-        setFilterProgress({
-          matched: matchedCount,
-          scanned: scannedCount,
-          total: totalLines,
-        })
+        if (generationRef.current === gen) {
+          setFilterProgress({
+            matched: matchedCount,
+            scanned: scannedCount,
+            total: totalLines,
+          })
+        }
       } catch (err: unknown) {
         if ((err as Error).name === 'AbortError') return
-        const msg = err instanceof Error ? err.message : 'Filter stream error'
-        setError(msg)
+        if (generationRef.current === gen) {
+          const msg = err instanceof Error ? err.message : 'Filter stream error'
+          setError(msg)
+        }
       } finally {
-        setLoading(false)
+        if (generationRef.current === gen) {
+          setLoading(false)
+        }
       }
 
       return


### PR DESCRIPTION
## Summary

Refactors log loading from **eager** (load ALL entries into browser memory → client-side filtering) to **lazy** (stream only matching entries from backend on filter change).

## What Changed

### Backend (T1+T2+T3+T6)
| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/logs/filter/stream` | POST | Stream only matching entries + stats, with inline filter |
| `/logs/upload/temp` | POST | Save uploads to `~/.ala/temp_logs/{uuid}/`, return paths |
| `/logs/temp/status` | GET | Temp dir info (path, sessions, size) |
| `/logs/temp/cleanup` | POST | Delete sessions older than 24h |

- T2: Fixed `filter_logs()` keyword scope — now searches `message` + `raw_line` (was `tag + message`)
- T6: Startup cleanup of old temp files in `main.py` lifespan

### Frontend (T4)
- **New `useLazyLogStream` hook** — stores `sourceRef` instead of `allLogs`. `triggerFilter(filters)` streams only matches from backend.
- **`streamFilteredLogs()`** — API client calling `POST /logs/filter/stream`
- **`uploadToTemp()`** — API client for upload-to-temp

### Architecture
- Pure additive design — zero existing endpoints modified
- New hook sits alongside existing `useLogStream` — feature-gate switch in App.tsx planned for follow-up
- Pre-compiled filter matchers (`CompiledFilters` dataclass) avoid per-line regex recompilation
- Client disconnect detection every 100 lines

## Test Results
| Suite | Result |
|-------|--------|
| Backend | ✅ 268 passed, 7 skipped |
| Frontend (vitest) | 180 passed, 12 pre-existing failures (ProjectManager, unrelated) |
| TypeScript | ✅ tsc --noEmit: zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream and filter logs with real-time statistics and progress tracking
  * Upload log files temporarily for analysis and filtering
  * Monitor temporary file storage status
  * Automatic cleanup of old temporary uploads
  * Improved keyword filtering that checks both message and raw log content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagawagao/ala/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->