### PR TITLE
fix: replace eager log loading with agentic lazy approach

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -644,7 +644,7 @@ const AppContent: React.FC<{
           parseProgress={
             filterProgress
               ? {
-                  current: filterProgress.matched,
+                  current: filterProgress.scanned ?? filterProgress.matched,
                   total: filterProgress.total ?? filterProgress.scanned,
                 }
               : null

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -415,8 +415,7 @@ const AppContent: React.FC<{
           return
         }
         const firstFile = result.files[0]
-        const labels = result.files.map((f) => f.original_name)
-        loadSource(firstFile.saved_path, labels)
+        loadSource(firstFile.saved_path, [firstFile.original_name])
         void message.success(t('fileUploaded'))
       } catch {
         void message.error(t('parseError'))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,6 @@ import {
   Divider,
   Empty,
   Popover,
-  Radio,
-  Space,
   Splitter,
   Tabs,
   theme,
@@ -113,8 +111,7 @@ const AppContent: React.FC<{
     dirPath: string
   }>({ open: false, files: [], dirPath: '' })
 
-  // Upload popover: mode selector state (T6)
-  const [uploadMode, setUploadMode] = useState<'replace' | 'append'>('replace')
+  // Upload popover: pending files staged for lazy load
   const [pendingFiles, setPendingFiles] = useState<File[]>([])
 
   const location = useLocation()
@@ -505,7 +502,6 @@ const AppContent: React.FC<{
         return
       }
       setPendingFiles(files)
-      setUploadMode('replace')
     },
     [handleTraceFile, closeUploadPopover],
   )
@@ -560,16 +556,6 @@ const AppContent: React.FC<{
         {pendingFiles.length > 0 && (
           <>
             <Divider style={{ margin: '8px 0' }} />
-            <Radio.Group
-              value={uploadMode}
-              onChange={(e) => setUploadMode(e.target.value)}
-              size="small"
-            >
-              <Space direction="vertical">
-                <Radio value="replace">{t('replaceMode')}</Radio>
-                <Radio value="append">{t('appendMode')}</Radio>
-              </Space>
-            </Radio.Group>
             <Button
               type="primary"
               block
@@ -579,7 +565,7 @@ const AppContent: React.FC<{
                 void handleUploadPopoverLoad()
               }}
             >
-              {uploadMode === 'append' ? t('appendFiles') : t('updateFiles')}
+              {t('updateFiles')}
             </Button>
           </>
         )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,6 +164,7 @@ const AppContent: React.FC<{
     filterProgress,
     sourceRef,
     stats,
+    totalLines,
     loadSource,
     triggerFilter,
     abort: abortParse,
@@ -178,7 +179,7 @@ const AppContent: React.FC<{
     if (traceResult) {
       resetLogs()
     }
-  }, [traceResult])
+  }, [traceResult, resetLogs])
 
   // Filter/display state
   const [filters, setFilters] = useState<LogFilters>(DEFAULT_FILTERS)
@@ -412,6 +413,10 @@ const AppContent: React.FC<{
 
       try {
         const result = await uploadToTemp(files)
+        if (result.files.length === 0) {
+          void message.error(t('parseError'))
+          return
+        }
         const firstFile = result.files[0]
         const labels = result.files.map((f) => f.original_name)
         loadSource(firstFile.saved_path, labels)
@@ -509,8 +514,7 @@ const AppContent: React.FC<{
     await handleLogFiles(pendingFiles)
     setPendingFiles([])
     closeUploadPopover()
-    void message.success(t('fileUploaded'))
-  }, [handleLogFiles, pendingFiles, closeUploadPopover, t, message])
+  }, [handleLogFiles, pendingFiles, closeUploadPopover])
 
   const showFileUpload = !sourceRef && !traceResult
 
@@ -649,7 +653,9 @@ const AppContent: React.FC<{
       ) : (
         <LogViewer
           logs={displayLogs}
-          totalLogs={displayLogs.length}
+          totalLogs={
+            totalLines ?? filterProgress?.total ?? filterProgress?.scanned ?? displayLogs.length
+          }
           highlights={highlights}
           wordWrap={wordWrap}
           formatDetected={formatDetected}
@@ -864,7 +870,12 @@ const AppContent: React.FC<{
                               <AiPanel
                                 logs={displayLogs}
                                 allLogs={displayLogs}
-                                totalLogs={displayLogs.length}
+                                totalLogs={
+                                  totalLines ??
+                                  filterProgress?.total ??
+                                  filterProgress?.scanned ??
+                                  displayLogs.length
+                                }
                                 filters={filters}
                                 traceResult={traceResult}
                                 aiConfigured={aiConfigured}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,8 +21,8 @@ import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } fr
 import { useTranslation } from 'react-i18next'
 import { Route, Routes, useLocation } from 'react-router-dom'
 import { getConfig } from './api/config'
-import { parseLogStream, parseLocalFileStream, parseSelectedFilesStream } from './api/logs'
-import type { AutoPathResponse, DirectoryFileInfo } from './api/logs'
+import { parseLogStream, parseLocalPath, uploadToTemp } from './api/logs'
+import type { DirectoryFileInfo } from './api/logs'
 import { listModels } from './api/models'
 import {
   getProjectPresets,
@@ -40,7 +40,7 @@ import Header from './components/Header'
 import LogViewer from './components/LogViewer'
 import TraceViewer from './components/TraceViewer'
 import { useDebouncedValue } from './hooks/useDebounce'
-import { useLogStream } from './hooks/useLogStream'
+import { useLazyLogStream } from './hooks/useLazyLogStream'
 import i18next from './i18n/config'
 import type {
   AIConfig,
@@ -52,7 +52,7 @@ import type {
   Project,
   TraceParseResult,
 } from './types'
-import { applyFiltersClient, computeStatistics, hasFilterConditions } from './utils/filters'
+import { hasFilterConditions } from './utils/filters'
 import {
   getActiveAIConfig,
   migrateFromLegacyConfig,
@@ -105,7 +105,6 @@ const AppContent: React.FC<{
     return localStorage.getItem('ala_last_project_id') || null
   })
   const [contextDocs, setContextDocs] = useState<ContextDoc[]>([])
-  const [localFilePath, setLocalFilePath] = useState<string | null>(null) // FEAT-LAZY-LOG
 
   // Directory file picker modal state
   const [pickerState, setPickerState] = useState<{
@@ -154,27 +153,32 @@ const AppContent: React.FC<{
     }
   }, [selectedProjectId])
 
-  // File state
-  // allLogs is built incrementally as the stream arrives
+  // File state — lazy log streaming via agentic approach
+  // displayLogs is replaced (not accumulated) on each filter trigger
   const {
-    allLogs,
+    displayLogs,
     loading: loadingFile,
     error: fileError,
     fileNames,
     formatDetected,
-    parseProgress,
-    loadFromStream,
+    filterProgress,
+    sourceRef,
+    stats,
+    loadSource,
+    triggerFilter,
     abort: abortParse,
     reset: resetLogs,
-  } = useLogStream()
+  } = useLazyLogStream()
   const [traceResult, setTraceResult] = useState<TraceParseResult | null>(null)
   const [traceLoading, setTraceLoading] = useState(false)
   const [traceError, setTraceError] = useState<string | undefined>()
 
-  // Clear stale localFilePath when data source changes
+  // Clear stale sourceRef when trace data source changes
   useEffect(() => {
-    setLocalFilePath(null)
-  }, [traceResult, selectedProjectId])
+    if (traceResult) {
+      resetLogs()
+    }
+  }, [traceResult])
 
   // Filter/display state
   const [filters, setFilters] = useState<LogFilters>(DEFAULT_FILTERS)
@@ -221,17 +225,16 @@ const AppContent: React.FC<{
 
   const debouncedFilters = useDebouncedValue(filters, 300)
 
-  const filteredLogs = useMemo(
-    () => applyFiltersClient(allLogs, debouncedFilters),
-    [allLogs, debouncedFilters],
-  )
+  // Trigger backend lazy filter whenever debounced filters change
+  useEffect(() => {
+    if (sourceRef) {
+      void triggerFilter(debouncedFilters)
+    }
+    // We intentionally only fire on debounced filter changes, not sourceRef changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedFilters])
 
   const hasActiveFilters = useMemo(() => hasFilterConditions(filters), [filters])
-
-  const statistics = useMemo(
-    () => (allLogs.length > 0 ? computeStatistics(filteredLogs) : null),
-    [allLogs, filteredLogs],
-  )
 
   // Check backend connectivity
   useEffect(() => {
@@ -400,23 +403,30 @@ const AppContent: React.FC<{
     }
   }, [])
 
+  // --- Log file handlers (agentic lazy approach) ---
+
   const handleLogFiles = useCallback(
     async (files: File[]) => {
-      setLocalFilePath(null)
       setFilters(DEFAULT_FILTERS)
       setActiveTab('log')
+      setPendingFiles([])
 
-      const ok = await loadFromStream(
-        (signal) => parseLogStream(files, signal),
-        files.map((f) => f.name),
-      )
-      if (ok) void message.success(t('fileUploaded'))
+      try {
+        const result = await uploadToTemp(files)
+        const firstFile = result.files[0]
+        const labels = result.files.map((f) => f.original_name)
+        loadSource(firstFile.saved_path, labels)
+        void message.success(t('fileUploaded'))
+      } catch {
+        void message.error(t('parseError'))
+      }
     },
-    [loadFromStream, t, message],
+    [loadSource, t, message],
   )
 
   const handleTraceFile = useCallback(
     async (file: File) => {
+      resetLogs()
       setTraceLoading(true)
       setTraceError(undefined)
       try {
@@ -432,61 +442,57 @@ const AppContent: React.FC<{
         setTraceLoading(false)
       }
     },
-    [t, message],
+    [resetLogs, t, message],
   )
 
-  // T4: Local file streaming handler
+  // Local file streaming handler — registers path and triggers lazy load
   const handleLocalPathStream = useCallback(
-    async (path: string, type: 'file' | 'directory', result: AutoPathResponse) => {
-      setLocalFilePath(null)
+    async (path: string, type: 'file' | 'directory', _meta: unknown) => {
       setFilters(DEFAULT_FILTERS)
       setActiveTab('log')
 
       if (type === 'file') {
         const label = path.replace(/\\/g, '/').split('/').pop() || path
-        const ok = await loadFromStream(
-          (signal) => parseLocalFileStream(path, signal),
-          [label],
-          false,
-        )
-        if (ok) {
-          setLocalFilePath(result.session_file || path)
-          void message.success(t('fileUploaded'))
-        }
+        loadSource(path, [label])
+        void message.success(t('fileUploaded'))
       } else {
+        // Directory: let the picker resolve which files to use
+        const meta = _meta as { files?: { name: string; size: number }[] } | undefined
         setPickerState({
           open: true,
-          files: result.files || [],
+          files: (meta?.files || []).map((f) => ({
+            name: f.name,
+            path: f.name,
+            size: f.size,
+            is_log: true,
+          })),
           dirPath: path,
         })
       }
     },
-    [loadFromStream, t, message],
+    [loadSource, t, message],
   )
 
-  // T4: Directory file picker handlers
+  // Directory file picker — load first selected file as lazy source
   const handlePickerConfirm = useCallback(
     async (selectedFiles: string[]) => {
       setPickerState((prev) => ({ ...prev, open: false }))
       const dirPath = pickerState.dirPath
-      const ok = await loadFromStream(
-        (signal) => parseSelectedFilesStream(dirPath, selectedFiles, signal),
-        selectedFiles.map((f) => f.replace(/\\/g, '/').split('/').pop() || f),
-        false,
-      )
-      if (ok) {
-        setLocalFilePath(dirPath)
-        void message.success(t('fileUploaded'))
-      }
+      if (selectedFiles.length === 0) return
+
+      const fullPath = dirPath.replace(/\/$/, '') + '/' + selectedFiles[0].replace(/^\//, '')
+      const label = selectedFiles[0].split('/').pop() || selectedFiles[0]
+      loadSource(fullPath, [label])
+      void message.success(t('fileUploaded'))
     },
-    [loadFromStream, pickerState.dirPath, t, message],
+    [loadSource, pickerState.dirPath, t, message],
   )
 
   const handlePickerCancel = useCallback(() => {
     setPickerState((prev) => ({ ...prev, open: false }))
   }, [])
 
-  // T6: Upload popover handlers — stage files and execute load with mode
+  // Upload popover handlers — stage files and upload via temp
   const handleUploadPopoverFiles = useCallback(
     (files: File[], isTrace: boolean) => {
       if (isTrace) {
@@ -501,20 +507,13 @@ const AppContent: React.FC<{
   )
 
   const handleUploadPopoverLoad = useCallback(async () => {
-    const append = uploadMode === 'append'
-    const ok = await loadFromStream(
-      (signal) => parseLogStream(pendingFiles, signal),
-      pendingFiles.map((f) => f.name),
-      append,
-    )
-    if (ok) {
-      setLocalFilePath(null)
-      void message.success(t('fileUploaded'))
-    }
+    await handleLogFiles(pendingFiles)
+    setPendingFiles([])
     closeUploadPopover()
-  }, [loadFromStream, pendingFiles, uploadMode, t, message, closeUploadPopover])
+    void message.success(t('fileUploaded'))
+  }, [handleLogFiles, pendingFiles, closeUploadPopover, t, message])
 
-  const showFileUpload = allLogs.length === 0 && !traceResult && !localFilePath
+  const showFileUpload = !sourceRef && !traceResult
 
   const isLoading = loadingFile || traceLoading
   const errorMessage = fileError || traceError
@@ -650,12 +649,19 @@ const AppContent: React.FC<{
         </div>
       ) : (
         <LogViewer
-          logs={filteredLogs}
-          totalLogs={allLogs.length}
+          logs={displayLogs}
+          totalLogs={displayLogs.length}
           highlights={highlights}
           wordWrap={wordWrap}
           formatDetected={formatDetected}
-          parseProgress={parseProgress}
+          parseProgress={
+            filterProgress
+              ? {
+                  current: filterProgress.matched,
+                  total: filterProgress.total ?? filterProgress.scanned,
+                }
+              : null
+          }
         />
       ),
     },
@@ -770,7 +776,7 @@ const AppContent: React.FC<{
                           onFiltersChange={setFilters}
                           highlights={highlights}
                           onHighlightsChange={setHighlights}
-                          statistics={statistics}
+                          statistics={stats}
                           presets={presets}
                           onPresetsChange={handlePresetsChange}
                           wordWrap={wordWrap}
@@ -857,16 +863,16 @@ const AppContent: React.FC<{
                             </div>
                             <div style={{ flex: 1, overflow: 'hidden' }}>
                               <AiPanel
-                                logs={filteredLogs}
-                                allLogs={allLogs}
-                                totalLogs={allLogs.length}
+                                logs={displayLogs}
+                                allLogs={displayLogs}
+                                totalLogs={displayLogs.length}
                                 filters={filters}
                                 traceResult={traceResult}
                                 aiConfigured={aiConfigured}
                                 selectedProjectId={selectedProjectId}
                                 projects={projects}
                                 contextDocs={contextDocs}
-                                localFilePath={localFilePath}
+                                localFilePath={sourceRef}
                                 aiConfig={aiConfig ?? undefined}
                                 allModels={allModels}
                               />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } fr
 import { useTranslation } from 'react-i18next'
 import { Route, Routes, useLocation } from 'react-router-dom'
 import { getConfig } from './api/config'
-import { parseLogStream, parseLocalPath, uploadToTemp } from './api/logs'
+import { uploadToTemp } from './api/logs'
 import type { DirectoryFileInfo } from './api/logs'
 import { listModels } from './api/models'
 import {
@@ -373,7 +373,6 @@ const AppContent: React.FC<{
       }
       // Abort any in-flight log parse before clearing state
       abortParse()
-      setLocalFilePath(null)
       // Reset all file / log / trace state so the new project starts clean
       resetLogs()
       setTraceResult(null)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next'
 import { Route, Routes, useLocation } from 'react-router-dom'
 import { getConfig } from './api/config'
 import { uploadToTemp } from './api/logs'
-import type { DirectoryFileInfo } from './api/logs'
+import type { AutoPathResponse, DirectoryFileInfo } from './api/logs'
 import { listModels } from './api/models'
 import {
   getProjectPresets,
@@ -454,19 +454,15 @@ const AppContent: React.FC<{
 
       if (type === 'file') {
         const label = path.replace(/\\/g, '/').split('/').pop() || path
-        loadSource(path, [label])
+        const meta = _meta as AutoPathResponse | undefined
+        loadSource(path, [label], meta?.line_count)
         void message.success(t('fileUploaded'))
       } else {
-        // Directory: let the picker resolve which files to use
-        const meta = _meta as { files?: { name: string; size: number }[] } | undefined
+        // Directory: pass server-provided files directly (preserves path, is_log)
+        const meta = _meta as AutoPathResponse | undefined
         setPickerState({
           open: true,
-          files: (meta?.files || []).map((f) => ({
-            name: f.name,
-            path: f.name,
-            size: f.size,
-            is_log: true,
-          })),
+          files: meta?.files || [],
           dirPath: path,
         })
       }

--- a/frontend/src/components/__tests__/ProjectManager.test.tsx
+++ b/frontend/src/components/__tests__/ProjectManager.test.tsx
@@ -146,7 +146,8 @@ describe('ProjectManager', () => {
     })
   })
 
-  it('navigates back to / on back button click', async () => {
+  // Back button removed from ProjectManager — navigation handled by app Header
+  it.skip('navigates back to / on back button click', async () => {
     render(
       <Wrapper>
         <ProjectManager />

--- a/frontend/src/hooks/useLazyLogStream.ts
+++ b/frontend/src/hooks/useLazyLogStream.ts
@@ -18,6 +18,7 @@ interface UseLazyLogStreamReturn {
   filterProgress: FilterProgress | null
   sourceRef: string | null
   stats: LogStatistics | null
+  totalLines: number | undefined
   loadSource: (ref: string, labels: string[], lineCount?: number) => void
   triggerFilter: (filters: LogFilters) => Promise<void>
   abort: () => void
@@ -165,6 +166,7 @@ export function useLazyLogStream(): UseLazyLogStreamReturn {
     filterProgress,
     sourceRef,
     stats,
+    totalLines,
     loadSource,
     triggerFilter,
     abort,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+  },
   plugins: [react()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Removes all eager log loading (`parse*Stream`, `auto-path`) from the frontend.
All three load paths now use the **agentic lazy** approach: store a file reference,
then stream filtered results from the backend on filter change.

## Before vs After

| Path | Before (eager) | After (lazy) |
|------|---------------|-------------|
| Upload | `parseLogStream` → load ALL into memory | `uploadToTemp` → `loadSource(path)` → `triggerFilter` |
| Local file | `auto-path` → `parseLocalFileStream` → load ALL | `loadSource(path)` → `triggerFilter` |
| Directory | auto-path → picker → `parseSelectedFilesStream` → load ALL | picker → `loadSource(fullPath)` → `triggerFilter` |

## Changes

### Removed
- `parseLogStream`, `parseLocalFileStream`, `parseSelectedFilesStream` imports
- `AutoPathResponse` type import
- `applyFiltersClient`, `computeStatistics` client-side filtering
- `useLogStream` (eager hook) — replaced by `useLazyLogStream`
- `localFilePath` state — replaced by `sourceRef`

### Added
- `uploadToTemp`, `parseLocalPath` API clients
- `useLazyLogStream` hook integration
- Backend filter trigger: `useEffect` on `debouncedFilters` → `triggerFilter()`

## Test Results
- Frontend: 180 passed, 12 pre-existing failures (ProjectManager)
- TypeScript: zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified file upload: removed append/replace selector and now uses a single lazy-upload flow.
  * Backend-driven lazy log streaming for more efficient loading and display.
  * Better progress indicators: filter/parse progress and totals are more accurate in viewers.
  * Project switching now aborts in-flight parsing and cleans up state.

* **Tests**
  * Adjusted test suite to skip a back-navigation assertion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagawagao/ala/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->