### PR TITLE
fix: add socket and _ssl to PyInstaller hidden imports for Windows

### DIFF
--- a/backend/ala.spec
+++ b/backend/ala.spec
@@ -86,6 +86,10 @@ for _pkg in (
 # Hidden imports that PyInstaller's static analysis misses
 # ---------------------------------------------------------------------------
 hiddenimports = [
+    # Python stdlib C extensions sometimes missed on Windows
+    "socket",          # ensures _socket.pyd is bundled (fixes pyi_rth_multiprocessing crash)
+    "_ssl",            # also a C extension; belt-and-suspenders
+
     # uvicorn internals loaded dynamically
     "uvicorn.logging",
     "uvicorn.loops",


### PR DESCRIPTION
## Problem

Running `ala.exe` on Windows crashes immediately with:

```
ModuleNotFoundError: No module named '_socket'
```

The error occurs in PyInstaller's `pyi_rth_multiprocessing` runtime hook, which runs **before** application code. The import chain is:

```
pyi_rth_multiprocessing → multiprocessing → reduction → socket → _socket ❌
```

`_socket` is a Python C extension (`.pyd`) that PyInstaller fails to automatically collect on Windows, even though uvicorn (which imports `multiprocessing` internally) is the application's server runtime.

## Fix

Explicitly declare `socket` and `_ssl` in the `hiddenimports` list of `ala.spec`. This forces PyInstaller's analysis phase to trace `socket.py` and bundle its C extension dependency `_socket.pyd`.

## Rebuild

After merging, rebuild on the Windows build machine:

```powershell
cd backend
poetry run pyinstaller ala.spec --clean --noconfirm
```

The `--clean` flag ensures PyInstaller's cache is cleared so the new hidden imports take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of compiled versions on Windows by ensuring necessary system modules are properly included in the application bundle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagawagao/ala/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->