### PR TITLE
feat: bugreport .zip auto-detection, extraction, and file routing

### DIFF
--- a/backend/src/ala/api/files.py
+++ b/backend/src/ala/api/files.py
@@ -51,6 +51,9 @@ class UnifiedFileInfo(BaseModel):
 class UnifiedUploadResponse(BaseModel):
     session_uuid: str
     files: list[UnifiedFileInfo]
+    # Bugreport-specific fields (populated only when a bugreport .zip is detected)
+    bugreport_files: list[dict] | None = None
+    bugreport_extracted: bool = False
 
 
 # ── Endpoint ───────────────────────────────────────────────────────────
@@ -72,6 +75,8 @@ async def unified_upload(files: list[UploadFile] = File(...)):
 
     session_uuid = str(uuid.uuid4())
     result_files: list[UnifiedFileInfo] = []
+    bugreport_files: list[dict] | None = None
+    bugreport_extracted = False
 
     for upload in files:
         # Read enough of the file to detect type (up to 8 KB)
@@ -137,6 +142,72 @@ async def unified_upload(files: list[UploadFile] = File(...)):
         with os.fdopen(fd, "wb") as f:
             f.write(content)
 
+        # ── Bugreport .zip detection and auto-extraction ─────────────────
+        if file_type == "log" and content[:2] == b"\x50\x4b":  # ZIP magic
+            try:
+                from ..config import settings
+                from ..services.bugreport_router import extract_bugreport, is_bugreport_zip
+                from ..services.session_manager import SessionManager
+
+                if is_bugreport_zip(str(dest_path)):
+                    extract_dir = str(dest_path) + "_extracted"
+                    extracted = extract_bugreport(str(dest_path), extract_dir)
+
+                    # Add the zip itself to result files
+                    result_files.append(
+                        UnifiedFileInfo(
+                            original_name=filename,
+                            saved_path=str(dest_path),
+                            size_bytes=len(content),
+                            file_type=file_type,
+                            format_detected="bugreport_zip",
+                        )
+                    )
+
+                    # Populate bugreport-specific response fields
+                    bugreport_files = [
+                        {
+                            "path": ef.path,
+                            "original_name": ef.original_name,
+                            "classified_type": ef.classified_type,
+                            "size": ef.size,
+                        }
+                        for ef in extracted
+                    ]
+                    bugreport_extracted = True
+
+                    # Create a session and set the source_path to the extracted dir
+                    from datetime import UTC, datetime
+
+                    _sm = SessionManager(max_sessions=settings.max_sessions)
+                    _sm._db.execute(
+                        "INSERT OR REPLACE INTO sessions (id, title, context_type, source_path, created_at) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        (
+                            session_uuid,
+                            f"Bugreport: {filename}",
+                            "bugreport",
+                            extract_dir,
+                            datetime.now(UTC).isoformat(),
+                        ),
+                    )
+                    _sm._db.commit()
+
+                    logger.info(
+                        "Bugreport extracted: %d files from %s",
+                        len(extracted),
+                        filename,
+                    )
+                    continue  # skip normal format detection for this file
+            except Exception as exc:
+                logger.warning(
+                    "Bugreport detection/extraction failed for %r: %s — "
+                    "falling back to normal zip handling",
+                    filename,
+                    exc,
+                )
+                # Fall through to normal zip handling below
+
         # Detect format-specific sub-type
         format_detected = "unknown"
         try:
@@ -174,4 +245,9 @@ async def unified_upload(files: list[UploadFile] = File(...)):
         [f.file_type for f in result_files],
     )
 
-    return UnifiedUploadResponse(session_uuid=session_uuid, files=result_files)
+    return UnifiedUploadResponse(
+        session_uuid=session_uuid,
+        files=result_files,
+        bugreport_files=bugreport_files,
+        bugreport_extracted=bugreport_extracted,
+    )

--- a/backend/src/ala/services/ai_service.py
+++ b/backend/src/ala/services/ai_service.py
@@ -425,6 +425,49 @@ class AIService:
                 )
             parts.append(lazy_hint)
 
+            # ── Bugreport directory hint ────────────────────────────────────
+            # When source_path is a directory, check for bugreport-characteristic
+            # files and provide a summary to help the AI navigate the contents.
+            try:
+                from .bugreport_router import classify_extracted_file as _classify
+            except ImportError:
+                pass
+            else:
+                file_types: dict[str, int] = {}
+                try:
+                    for entry in os.scandir(source_path):
+                        if entry.is_file():
+                            try:
+                                ft = _classify(entry.path)
+                            except Exception:
+                                ft = "other"
+                            file_types[ft] = file_types.get(ft, 0) + 1
+                except OSError:
+                    pass
+
+                if file_types:
+                    type_names = {
+                        "log": "log",
+                        "pcap": "PCAP",
+                        "hci": "HCI",
+                        "trace": "trace",
+                        "anr": "ANR trace",
+                        "tombstone": "tombstone",
+                        "other": "other",
+                    }
+                    summary_parts = [
+                        f"{count} {type_names.get(ft, ft)}"
+                        for ft, count in sorted(file_types.items())
+                    ]
+                    bugreport_hint = (
+                        f"Bugreport directory: {', '.join(summary_parts)}. "
+                        f"Use list_directory_logs to discover all files. "
+                        f"Use read_log_file(file_path='...') to read specific diagnostic "
+                        f"files (ANR traces, tombstones). "
+                        f"Use overview_local_log/search_local_log for large log files."
+                    )
+                    parts.append(bugreport_hint)
+
         if trace_summary:
             tools.extend(TRACE_TOOLS)
             meta = trace_summary.get("metadata", {})

--- a/backend/src/ala/services/bugreport_router.py
+++ b/backend/src/ala/services/bugreport_router.py
@@ -1,0 +1,263 @@
+"""Bugreport .zip auto-routing — detection, extraction, and file classification.
+
+Pure stdlib implementation that sits above ``file_detector`` without
+modifying it.  All errors return graceful fallbacks — never crash the
+upload flow.
+"""
+
+import logging
+import os
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..file_detector import detect_file_type_from_header
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+BUGREPORT_FILENAME_RE = re.compile(r"^bugreport(-.*)?\.zip$", re.I)
+
+# EOCD internal-structure detection patterns
+HIGH_WEIGHT_GLOBS = ["bugreport-*.txt", "ANR-*.txt", "tombstone_*"]
+MEDIUM_WEIGHT_GLOBS = ["dumpstate_*.txt", "dumpsys.txt"]
+LOW_WEIGHT_GLOBS = ["proto/*", "version.txt"]
+
+# Zip bomb limits
+MAX_COMPRESSION_RATIO = 100
+MAX_UNCOMPRESSED_BOMB_BYTES = 500 * 1024 * 1024  # 500 MB
+MAX_FILE_COUNT = 10_000
+
+# Max header bytes to read for content-based classification
+CLASSIFY_HEADER_BYTES = 4096
+
+
+# ── Data structures ──────────────────────────────────────────────────────
+
+
+@dataclass
+class ExtractedFileInfo:
+    """Metadata about a single extracted file from a bugreport zip."""
+
+    path: str  # absolute path on disk
+    original_name: str  # relative filename within the zip
+    classified_type: str  # "log" | "pcap" | "hci" | "trace" | "anr" | "tombstone" | "other"
+    size: int  # file size in bytes
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def is_bugreport_zip(file_path: str) -> bool:
+    """Detect whether *file_path* is a bugreport .zip.
+
+    Two-layer detection (fast-first):
+    1. Filename pattern: ``^bugreport(-.*)?.zip$``
+    2. Internal EOCD probe: look for characteristic files inside the zip
+    """
+    filename = os.path.basename(file_path)
+
+    # Layer 1: filename pattern match
+    if BUGREPORT_FILENAME_RE.match(filename):
+        return True
+
+    # Layer 2: internal structure probe via ZIP central directory
+    try:
+        with zipfile.ZipFile(file_path) as zf:
+            names = [info.filename for info in zf.infolist()]
+    except (zipfile.BadZipFile, OSError, RuntimeError):
+        return False
+
+    if not names:
+        return False
+
+    # Score characteristic files
+    high = _count_matching(names, HIGH_WEIGHT_GLOBS)
+    medium = _count_matching(names, MEDIUM_WEIGHT_GLOBS)
+    low = _count_matching(names, LOW_WEIGHT_GLOBS)
+
+    # Detection rule: high>=2 OR (high>=1 AND medium+low>=2)
+    if high >= 2:
+        return True
+    if high >= 1 and (medium + low) >= 2:
+        return True
+
+    return False
+
+
+def extract_bugreport(zip_path: str, output_dir: str) -> list[ExtractedFileInfo]:
+    """Extract a bugreport .zip into *output_dir* and classify every file.
+
+    Returns a list of :class:`ExtractedFileInfo` for each extracted file.
+    Raises ``ValueError`` on zip bomb or corrupt zip.
+    """
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+
+    # ── Security pre-check: zip bomb & file count ──────────────────────
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            infos = zf.infolist()
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"Corrupt zip file: {e}") from e
+    except RuntimeError as e:
+        raise ValueError(f"Encrypted or unreadable zip: {e}") from e
+
+    if len(infos) > MAX_FILE_COUNT:
+        raise ValueError(f"Zip contains {len(infos)} files — exceeds maximum of {MAX_FILE_COUNT}")
+
+    total_compressed = sum(info.compress_size for info in infos)
+    total_uncompressed = sum(info.file_size for info in infos)
+    if total_compressed > 0:
+        ratio = total_uncompressed / total_compressed
+        if ratio > MAX_COMPRESSION_RATIO and total_uncompressed > MAX_UNCOMPRESSED_BOMB_BYTES:
+            raise ValueError(
+                f"Zip bomb detected: compression ratio {ratio:.0f}:1 "
+                f"with uncompressed size {total_uncompressed:,} bytes"
+            )
+
+    # ── Extract ────────────────────────────────────────────────────────
+    # Reuse the battle-tested extraction logic from log_analyzer.
+    # It handles path-traversal protection, mtime-based caching, and
+    # the {path}_extracted directory convention.
+    from .log_analyzer import _extract_archive_to_disk  # noqa: PLC0415
+
+    filename = os.path.basename(zip_path)
+    actual_extract_dir = _extract_archive_to_disk(zip_path, filename)
+
+    # ── Collect and classify extracted files ───────────────────────────
+    results: list[ExtractedFileInfo] = []
+    for root, _dirs, files in os.walk(actual_extract_dir):
+        for fname in files:
+            # Skip ALA internal marker files
+            if fname.startswith(".ala_"):
+                continue
+            full_path = os.path.join(root, fname)
+            # Path traversal guard — ensure path stays within extract dir
+            if not _is_within_base(str(actual_extract_dir), full_path):
+                logger.warning("Skipping path outside extract dir: %s", full_path)
+                continue
+            try:
+                fsize = os.path.getsize(full_path)
+            except OSError:
+                continue
+            classified = classify_extracted_file(full_path)
+            rel_name = os.path.relpath(full_path, actual_extract_dir)
+            results.append(
+                ExtractedFileInfo(
+                    path=full_path,
+                    original_name=rel_name,
+                    classified_type=classified,
+                    size=fsize,
+                )
+            )
+
+    logger.info(
+        "Bugreport extracted: %d files from %s → %s",
+        len(results),
+        zip_path,
+        actual_extract_dir,
+    )
+    return results
+
+
+def classify_extracted_file(file_path: str) -> str:
+    """Classify a single extracted file into one of the known types.
+
+    Returns one of: ``"log"``, ``"pcap"``, ``"hci"``, ``"trace"``,
+    ``"anr"``, ``"tombstone"``, ``"other"``.
+    """
+    filename = os.path.basename(file_path)
+    basename = filename
+
+    # ── Layer 1: filename patterns (fastest) ──────────────────────────
+    if re.match(r"^bugreport-.*\.txt$", basename, re.I):
+        return "log"
+    if re.match(r"^ANR-.*\.txt$", basename, re.I):
+        return "anr"
+    if basename.startswith("tombstone_"):
+        return "tombstone"
+
+    # ── Layer 2: extension hints ──────────────────────────────────────
+    ext = os.path.splitext(filename)[1].lower()
+    if ext in (".pcap", ".pcapng"):
+        return "pcap"
+    if basename.lower().startswith("btsnoop_") or ext == ".cfa":
+        return "hci"
+    if ext in (".pb", ".perfetto-trace"):
+        return "trace"
+
+    # ── Layer 3: magic bytes via file_detector ────────────────────────
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(CLASSIFY_HEADER_BYTES)
+    except OSError:
+        return "other"
+
+    if not header:
+        return "other"
+
+    ft = detect_file_type_from_header(header)
+    if ft == "pcap":
+        return "pcap"
+    if ft == "hci":
+        return "hci"
+    if ft == "trace":
+        # Only accept trace classification if file looks like text/JSON
+        if _looks_like_text(header):
+            return "trace"
+        # Otherwise, binary data → fall through to 'other'
+
+    # ── Layer 4: content-based detection (text files) ─────────────────
+    try:
+        text = header.decode("utf-8", errors="replace")
+    except Exception:
+        return "other"
+
+    # ANR trace signature
+    if "----- pid" in text and "Cmd line:" in text:
+        return "anr"
+
+    # Tombstone signature
+    if "*** *** ***" in text and "Build fingerprint:" in text:
+        return "tombstone"
+
+    # ── Layer 5: text vs binary fallback ──────────────────────────────
+    if _looks_like_text(header):
+        return "log"
+
+    return "other"
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────
+
+
+def _count_matching(names: list[str], globs: list[str]) -> int:
+    """Count how many *globs* have at least one matching entry in *names*."""
+    import fnmatch
+
+    total = 0
+    for glob in globs:
+        if any(fnmatch.fnmatch(name, glob) for name in names):
+            total += 1
+    return total
+
+
+def _looks_like_text(header: bytes, threshold: int = 4) -> bool:
+    """Return True if *header* looks like printable text (low binary chars)."""
+    scan = header[:4096]
+    control = sum(1 for b in scan if b < 0x20 and b not in (0x09, 0x0A, 0x0D))
+    return control <= threshold
+
+
+def _is_within_base(base_dir: str, target_path: str) -> bool:
+    """Return True if *target_path* is within the *base_dir* tree (no traversal)."""
+    try:
+        base = Path(base_dir).resolve()
+        target = Path(target_path).resolve()
+        target.relative_to(base)
+        return True
+    except (ValueError, OSError):
+        return False

--- a/backend/src/ala/services/bugreport_router.py
+++ b/backend/src/ala/services/bugreport_router.py
@@ -110,6 +110,15 @@ def extract_bugreport(zip_path: str, output_dir: str) -> list[ExtractedFileInfo]
 
     total_compressed = sum(info.compress_size for info in infos)
     total_uncompressed = sum(info.file_size for info in infos)
+
+    # Independent uncompressed-size guard — catches low-compression
+    # ZIPs that would otherwise bypass the ratio-based bomb check.
+    if total_uncompressed > MAX_UNCOMPRESSED_BOMB_BYTES:
+        raise ValueError(
+            f"Zip too large: uncompressed size {total_uncompressed:,} bytes "
+            f"exceeds maximum of {MAX_UNCOMPRESSED_BOMB_BYTES:,} bytes"
+        )
+
     if total_compressed > 0:
         ratio = total_uncompressed / total_compressed
         if ratio > MAX_COMPRESSION_RATIO and total_uncompressed > MAX_UNCOMPRESSED_BOMB_BYTES:
@@ -119,13 +128,21 @@ def extract_bugreport(zip_path: str, output_dir: str) -> list[ExtractedFileInfo]
             )
 
     # ── Extract ────────────────────────────────────────────────────────
-    # Reuse the battle-tested extraction logic from log_analyzer.
-    # It handles path-traversal protection, mtime-based caching, and
-    # the {path}_extracted directory convention.
-    from .log_analyzer import _extract_archive_to_disk  # noqa: PLC0415
+    # Extract directly to *output_dir* after the security pre-checks above.
+    # Path-traversal protection: normalize each member path and reject
+    # absolute paths or parent-directory escapes.
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            for member in zf.infolist():
+                member_path = os.path.normpath(member.filename)
+                if member_path.startswith("..") or os.path.isabs(member_path):
+                    logger.warning("Skipping potentially unsafe path: %s", member.filename)
+                    continue
+                zf.extract(member, str(output))
+    except (zipfile.BadZipFile, OSError, RuntimeError) as e:
+        raise ValueError(f"Extraction failed: {e}") from e
 
-    filename = os.path.basename(zip_path)
-    actual_extract_dir = _extract_archive_to_disk(zip_path, filename)
+    actual_extract_dir = output
 
     # ── Collect and classify extracted files ───────────────────────────
     results: list[ExtractedFileInfo] = []

--- a/backend/tests/test_bugreport_router.py
+++ b/backend/tests/test_bugreport_router.py
@@ -1,0 +1,589 @@
+"""Tests for bugreport_router — detection, extraction, classification, and security."""
+
+import os
+import tempfile
+import zipfile
+
+import pytest
+
+from ala.services.bugreport_router import (
+    _count_matching,
+    _is_within_base,
+    _looks_like_text,
+    classify_extracted_file,
+    extract_bugreport,
+    is_bugreport_zip,
+)
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+def _create_zip(zip_path: str, files: dict[str, str | bytes]) -> None:
+    """Create a zip file with the given name→content mapping."""
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            zf.writestr(name, content)
+
+
+def _create_temp_zip(files: dict[str, str | bytes], suffix: str = ".zip") -> str:
+    """Create a temporary zip file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    _create_zip(path, files)
+    return path
+
+
+# ── is_bugreport_zip tests ─────────────────────────────────────────────────
+
+
+class TestIsBugreportZip:
+    def test_filename_pattern_basic(self):
+        """bugreport-YYYY-MM-DD.zip should be detected by filename pattern."""
+        path = _create_temp_zip({"bugreport-2026-06-26.txt": "log content"})
+        new_path = os.path.join(os.path.dirname(path), "bugreport-2026-06-26.zip")
+        os.rename(path, new_path)
+        try:
+            assert is_bugreport_zip(new_path) is True
+        finally:
+            os.unlink(new_path)
+
+    def test_filename_pattern_simple(self):
+        """bugreport.zip should be detected."""
+        path = _create_temp_zip({"some.txt": "content"})
+        new_path = os.path.join(os.path.dirname(path), "bugreport.zip")
+        os.rename(path, new_path)
+        try:
+            assert is_bugreport_zip(new_path) is True
+        finally:
+            os.unlink(new_path)
+
+    def test_filename_pattern_case_insensitive(self):
+        """BugReport.zip should be detected (case insensitive)."""
+        path = _create_temp_zip({"some.txt": "content"})
+        new_path = os.path.join(os.path.dirname(path), "BugReport-2026-06-26.zip")
+        os.rename(path, new_path)
+        try:
+            assert is_bugreport_zip(new_path) is True
+        finally:
+            os.unlink(new_path)
+
+    def test_filename_with_device_prefix(self):
+        """bugreport-PB2AX-2026-06-26-10-15-23.zip should match."""
+        path = _create_temp_zip({"some.txt": "content"})
+        new_path = os.path.join(os.path.dirname(path), "bugreport-PB2AX-2026-06-26-10-15-23.zip")
+        os.rename(path, new_path)
+        try:
+            assert is_bugreport_zip(new_path) is True
+        finally:
+            os.unlink(new_path)
+
+    def test_normal_zip_not_detected_by_filename(self):
+        """A normal zip with non-bugreport name should not match by filename."""
+        path = _create_temp_zip({"some.txt": "content"})
+        try:
+            assert is_bugreport_zip(path) is False
+        finally:
+            os.unlink(path)
+
+    def test_internal_structure_detection_high_weight(self):
+        """Zip with bugreport-*.txt + ANR-*.txt (2 high-weight) should be detected."""
+        path = _create_temp_zip(
+            {
+                "bugreport-2026-06-26.txt": "log content",
+                "ANR-2026-06-26-10-15-23.txt": "ANR content",
+            },
+            suffix="-logs.zip",
+        )
+        try:
+            assert is_bugreport_zip(path) is True
+        finally:
+            os.unlink(path)
+
+    def test_internal_structure_detection_tombstones(self):
+        """Zip with tombstone_00 + bugreport.txt should be detected."""
+        path = _create_temp_zip(
+            {
+                "bugreport-2026-06-26.txt": "log content",
+                "tombstone_00": "tombstone content",
+            },
+            suffix="-logs.zip",
+        )
+        try:
+            assert is_bugreport_zip(path) is True
+        finally:
+            os.unlink(path)
+
+    def test_internal_structure_one_high_two_medium(self):
+        """Zip with 1 high-weight + 2 medium-weight should be detected."""
+        path = _create_temp_zip(
+            {
+                "bugreport-2026-06-26.txt": "log content",
+                "dumpstate_log.txt": "dumpstate",
+                "dumpsys.txt": "dumpsys",
+            },
+            suffix="-logs.zip",
+        )
+        try:
+            assert is_bugreport_zip(path) is True
+        finally:
+            os.unlink(path)
+
+    def test_internal_structure_insufficient(self):
+        """Zip with only 1 high-weight and nothing else should not match."""
+        path = _create_temp_zip(
+            {"bugreport-2026-06-26.txt": "log content"},
+            suffix="-data.zip",
+        )
+        try:
+            assert is_bugreport_zip(path) is False
+        finally:
+            os.unlink(path)
+
+    def test_empty_zip_not_bugreport(self):
+        """Empty zip should not be detected as bugreport."""
+        path = _create_temp_zip({}, suffix="-empty.zip")
+        try:
+            assert is_bugreport_zip(path) is False
+        finally:
+            os.unlink(path)
+
+    def test_corrupt_zip_returns_false(self):
+        """A corrupt zip file should gracefully return False."""
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        os.write(fd, b"not a zip file at all")
+        os.close(fd)
+        try:
+            assert is_bugreport_zip(path) is False
+        finally:
+            os.unlink(path)
+
+    def test_non_existent_file_returns_false(self):
+        """Non-existent file with non-matching name should return False.
+
+        Note: /nonexistent/data.zip does NOT match the bugreport filename
+        pattern, and the file doesn't exist so EOCD probe also fails.
+        """
+        assert is_bugreport_zip("/nonexistent/path/data.zip") is False
+
+    def test_encrypted_zip_returns_false(self):
+        """Encrypted zip should return False gracefully (skip if pyzipper missing)."""
+        try:
+            import pyzipper  # noqa: F811
+        except ImportError:
+            pytest.skip("pyzipper not installed")
+            return
+
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        os.close(fd)
+        try:
+            with pyzipper.AESZipFile(
+                path, "w", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES
+            ) as zf:
+                zf.setpassword(b"secret")
+                zf.writestr("test.txt", "encrypted content")
+        except Exception:
+            os.unlink(path)
+            pytest.skip("pyzipper encryption failed")
+            return
+        try:
+            assert is_bugreport_zip(path) is False
+        finally:
+            os.unlink(path)
+
+
+# ── classify_extracted_file tests ──────────────────────────────────────────
+
+
+class TestClassifyExtractedFile:
+    def test_main_log_by_filename(self):
+        """bugreport-2026-06-26.txt should be classified as 'log'."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("01-15 10:30:45.123  1234  5678 E AndroidRuntime: FATAL")
+            path = f.name
+        new_path = os.path.join(os.path.dirname(path), "bugreport-2026-06-26.txt")
+        os.rename(path, new_path)
+        try:
+            assert classify_extracted_file(new_path) == "log"
+        finally:
+            os.unlink(new_path)
+
+    def test_anr_trace_by_filename(self):
+        """ANR-2026-06-26-10-15-23.txt should be classified as 'anr'."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("some content")
+            path = f.name
+        new_path = os.path.join(os.path.dirname(path), "ANR-2026-06-26-10-15-23.txt")
+        os.rename(path, new_path)
+        try:
+            assert classify_extracted_file(new_path) == "anr"
+        finally:
+            os.unlink(new_path)
+
+    def test_anr_trace_by_content(self):
+        """File containing '----- pid' and 'Cmd line:' should be classified as 'anr'."""
+        content = """----- pid 1234 at 2026-06-26 10:15:23 -----
+Cmd line: com.example.app
+"main" prio=5 tid=1 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x74a4c278 self=0xb400007cef804000
+  at android.os.MessageQueue.nativePollOnce(Native method)"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "anr"
+        finally:
+            os.unlink(path)
+
+    def test_tombstone_by_filename(self):
+        """tombstone_00 should be classified as 'tombstone'."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("some content")
+            path = f.name
+        new_path = os.path.join(os.path.dirname(path), "tombstone_00")
+        os.rename(path, new_path)
+        try:
+            assert classify_extracted_file(new_path) == "tombstone"
+        finally:
+            os.unlink(new_path)
+
+    def test_tombstone_by_content(self):
+        """File containing '*** *** ***' and 'Build fingerprint:' should be classified as 'tombstone'."""
+        content = """*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+Build fingerprint: 'google/sunfish/sunfish:13/TQ3A.230805.001/123456:user/release-keys'
+Revision: '0'
+ABI: 'arm64'
+Timestamp: 2026-06-26 10:15:23.456789+0000
+Process uptime: 12345s
+Cmdline: com.example.app
+pid: 1234, tid: 5678, name: crasher  >>> com.example.app <<<
+signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "tombstone"
+        finally:
+            os.unlink(path)
+
+    def test_pcap_by_extension(self):
+        """File with .pcap extension should be classified as 'pcap'."""
+        pcap_header = (
+            b"\xd4\xc3\xb2\xa1"  # magic
+            b"\x02\x00"  # major
+            b"\x04\x00"  # minor
+            b"\x00\x00\x00\x00"  # timezone
+            b"\x00\x00\x00\x00"  # sigfigs
+            b"\xff\xff\x00\x00"  # snaplen
+            b"\x01\x00\x00\x00"  # linktype
+        )
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".pcap", delete=False) as f:
+            f.write(pcap_header)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "pcap"
+        finally:
+            os.unlink(path)
+
+    def test_pcapng_by_extension(self):
+        """File with .pcapng extension should be classified as 'pcap'."""
+        pcapng_header = b"\x0a\x0d\x0d\x0a" + b"\x00" * 24
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".pcapng", delete=False) as f:
+            f.write(pcapng_header)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "pcap"
+        finally:
+            os.unlink(path)
+
+    def test_hci_by_filename(self):
+        """btsnoop_hci.log should be classified as 'hci'."""
+        hci_header = b"btsnoop\x00" + b"\x00" * 8
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".log", delete=False) as f:
+            f.write(hci_header)
+            path = f.name
+        new_path = os.path.join(os.path.dirname(path), "btsnoop_hci.log")
+        os.rename(path, new_path)
+        try:
+            assert classify_extracted_file(new_path) == "hci"
+        finally:
+            os.unlink(new_path)
+
+    def test_hci_by_extension(self):
+        """File with .cfa extension should be classified as 'hci'."""
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".cfa", delete=False) as f:
+            f.write(b"btsnoop\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "hci"
+        finally:
+            os.unlink(path)
+
+    def test_trace_by_extension(self):
+        """File with .pb extension should be classified as 'trace'."""
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".pb", delete=False) as f:
+            f.write(b"\x00" * 100)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "trace"
+        finally:
+            os.unlink(path)
+
+    def test_trace_by_magic(self):
+        """File with JSON trace markers should be classified as 'trace'."""
+        content = '{"traceEvents": [{"ph": "X", "name": "test"}]}'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "trace"
+        finally:
+            os.unlink(path)
+
+    def test_generic_log_fallback(self):
+        """Plain text file with no specific markers should be classified as 'log'."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("This is a generic log file\nwith multiple lines\nof plain text.")
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "log"
+        finally:
+            os.unlink(path)
+
+    def test_binary_file_other(self):
+        """Binary file should be classified as 'other'."""
+        # Create truly binary data — random bytes with many control chars
+        binary_data = bytes([i % 256 for i in range(1024)])
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".bin", delete=False) as f:
+            f.write(binary_data)
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "other"
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_other(self):
+        """Non-existent file should return 'other'."""
+        assert classify_extracted_file("/nonexistent/file.txt") == "other"
+
+    def test_empty_file(self):
+        """Empty file should return 'other'."""
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            assert classify_extracted_file(path) == "other"
+        finally:
+            os.unlink(path)
+
+
+# ── extract_bugreport tests ────────────────────────────────────────────────
+
+
+class TestExtractBugreport:
+    def test_extracts_and_classifies_files(self):
+        """Extract should produce correct ExtractedFileInfo list."""
+        anr_content = """----- pid 1234 at 2026-06-26 10:15:23 -----
+Cmd line: com.example.app
+"main" prio=5 tid=1 Native"""
+        tombstone_content = """*** *** *** *** *** *** *** *** *** ***
+Build fingerprint: 'google/sunfish/sunfish:13/...'"""
+
+        zip_path = _create_temp_zip(
+            {
+                "bugreport-2026-06-26.txt": "01-15 10:30:45.123  1234  5678 E Tag: message",
+                "ANR-2026-06-26-10-15-23.txt": anr_content,
+                "tombstone_00": tombstone_content,
+                "dumpsys.txt": "dumpsys content here",
+            },
+            suffix="-bugreport.zip",
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            results = extract_bugreport(zip_path, output_dir)
+
+            assert len(results) == 4
+
+            types = {r.original_name: r.classified_type for r in results}
+            assert types["bugreport-2026-06-26.txt"] == "log"
+            assert types["ANR-2026-06-26-10-15-23.txt"] == "anr"
+            assert types["tombstone_00"] == "tombstone"
+            # dumpsys.txt — generic text → log
+            assert types["dumpsys.txt"] == "log"
+
+            for r in results:
+                assert r.size > 0
+                assert os.path.isabs(r.path)
+                assert os.path.exists(r.path)
+
+        os.unlink(zip_path)
+
+    def test_extract_creates_directory_structure(self):
+        """Extract should create files in the output directory."""
+        zip_path = _create_temp_zip(
+            {"bugreport-2026-06-26.txt": "log content"},
+            suffix="-bugreport.zip",
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            results = extract_bugreport(zip_path, output_dir)
+            assert len(results) == 1
+            assert results[0].original_name == "bugreport-2026-06-26.txt"
+            assert results[0].classified_type == "log"
+            assert os.path.exists(results[0].path)
+
+        os.unlink(zip_path)
+
+    def test_extract_with_nested_directories(self):
+        """Extract should handle files in subdirectories."""
+        zip_path = _create_temp_zip(
+            {
+                "subdir/bugreport-2026-06-26.txt": "log content",
+                "subdir/data.txt": "some data",
+            },
+            suffix="-bugreport.zip",
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            results = extract_bugreport(zip_path, output_dir)
+            assert len(results) == 2
+            names = {r.original_name for r in results}
+            assert "subdir/bugreport-2026-06-26.txt" in names
+            assert "subdir/data.txt" in names
+
+        os.unlink(zip_path)
+
+    def test_corrupt_zip_raises(self):
+        """Corrupt zip should raise ValueError."""
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        os.write(fd, b"not a valid zip")
+        os.close(fd)
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with pytest.raises(ValueError, match="[Cc]orrupt"):
+                extract_bugreport(path, output_dir)
+
+        os.unlink(path)
+
+    def test_encrypted_zip_raises(self):
+        """Encrypted zip should raise ValueError (skip if pyzipper missing)."""
+        try:
+            import pyzipper  # noqa: F811
+        except ImportError:
+            pytest.skip("pyzipper not installed")
+            return
+
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        os.close(fd)
+        try:
+            with pyzipper.AESZipFile(
+                path, "w", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES
+            ) as zf:
+                zf.setpassword(b"secret")
+                zf.writestr("test.txt", "encrypted content")
+        except Exception:
+            os.unlink(path)
+            pytest.skip("pyzipper encryption failed")
+            return
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with pytest.raises(ValueError, match="[Ee]ncrypted|[Uu]nreadable"):
+                extract_bugreport(path, output_dir)
+
+        os.unlink(path)
+
+    def test_empty_zip_returns_empty_list(self):
+        """Empty zip should return an empty list."""
+        zip_path = _create_temp_zip({}, suffix="-bugreport.zip")
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            results = extract_bugreport(zip_path, output_dir)
+            assert results == []
+
+        os.unlink(zip_path)
+
+
+# ── Security tests ─────────────────────────────────────────────────────────
+
+
+class TestSecurity:
+    def test_zip_bomb_detection(self):
+        """Zip with extreme compression ratio should be rejected."""
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        os.close(fd)
+
+        # Create a zip bomb: lots of highly compressible data
+        huge_repeated = b"A" * (1024 * 1024)  # 1 MB of 'A's (compresses to ~1KB)
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for i in range(600):
+                zf.writestr(f"file_{i}.txt", huge_repeated)
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with pytest.raises(ValueError, match="[Zz]ip bomb|[Cc]ompression ratio"):
+                extract_bugreport(path, output_dir)
+
+        os.unlink(path)
+
+    def test_path_traversal_protection(self):
+        """Normal extraction should work (path traversal guarded in _extract_archive_to_disk)."""
+        zip_path = _create_temp_zip({"safe_file.txt": "content"}, suffix="-safe.zip")
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            results = extract_bugreport(zip_path, output_dir)
+            assert len(results) == 1
+            assert results[0].original_name == "safe_file.txt"
+
+        os.unlink(zip_path)
+
+    def test_is_within_base_valid(self):
+        """_is_within_base should return True for valid subpath."""
+        assert _is_within_base("/tmp", "/tmp/sub/file.txt") is True
+
+    def test_is_within_base_traversal(self):
+        """_is_within_base should return False for path traversal."""
+        assert _is_within_base("/tmp", "/etc/passwd") is False
+
+    def test_is_within_base_nonexistent(self):
+        """_is_within_base — nonexistent paths can still be logically within each other."""
+        # Both paths don't exist, but "sub" is logically within the base
+        assert _is_within_base("/nonexistent_base_12345", "/nonexistent_base_12345/sub") is True
+
+    def test_is_within_base_different_nonexistent(self):
+        """_is_within_base should return False for different nonexistent roots."""
+        assert _is_within_base("/nonexistent_a", "/nonexistent_b/file") is False
+
+
+# ── Internal helper tests ──────────────────────────────────────────────────
+
+
+class TestCountMatching:
+    def test_single_match(self):
+        assert _count_matching(["bugreport-2026-06-26.txt"], ["bugreport-*.txt"]) == 1
+
+    def test_no_match(self):
+        assert _count_matching(["other.txt"], ["bugreport-*.txt"]) == 0
+
+    def test_multiple_globs(self):
+        names = ["bugreport-2026-06-26.txt", "ANR-2026-06-26.txt", "other.txt"]
+        # other.txt matches other*
+        assert _count_matching(names, ["bugreport-*.txt", "ANR-*.txt", "other*"]) == 3
+
+    def test_one_name_satisfies_multiple_globs(self):
+        """Each glob is counted once if any name matches it."""
+        names = ["bugreport-2026-06-26.txt"]
+        assert _count_matching(names, ["bugreport-*.txt", "*-2026-*.txt"]) == 2
+
+
+class TestLooksLikeText:
+    def test_plain_text(self):
+        assert _looks_like_text(b"Hello, world!\nThis is text.") is True
+
+    def test_logcat_text(self):
+        text = b"01-15 10:30:45.123  1234  5678 E Tag: message\n"
+        assert _looks_like_text(text) is True
+
+    def test_binary_data(self):
+        assert _looks_like_text(bytes(range(256))) is False
+
+    def test_empty(self):
+        assert _looks_like_text(b"") is True

--- a/backend/tests/test_bugreport_router.py
+++ b/backend/tests/test_bugreport_router.py
@@ -519,7 +519,9 @@ class TestSecurity:
                 zf.writestr(f"file_{i}.txt", huge_repeated)
 
         with tempfile.TemporaryDirectory() as output_dir:
-            with pytest.raises(ValueError, match="[Zz]ip bomb|[Cc]ompression ratio"):
+            with pytest.raises(
+                ValueError, match="[Zz]ip bomb|[Cc]ompression ratio|[Zz]ip too large"
+            ):
                 extract_bugreport(path, output_dir)
 
         os.unlink(path)

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -1,4 +1,5 @@
 import { apiUploadMulti } from './client'
+import type { BugreportFileInfo } from '../types'
 
 export interface UnifiedFileInfo {
   original_name: string
@@ -25,6 +26,9 @@ export interface UnifiedFileInfo {
 export interface UnifiedUploadResponse {
   session_uuid: string
   files: UnifiedFileInfo[]
+  bugreport_extracted?: boolean
+  bugreport_files?: BugreportFileInfo[]
+  extract_dir?: string
 }
 
 export async function uploadFiles(files: File[]): Promise<UnifiedUploadResponse> {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1023,7 +1023,7 @@ const AppContent: React.FC<{
                   {f.original_name}
                 </Typography.Text>
                 <Tag color="orange" style={{ fontSize: 10, marginLeft: 4 }}>
-                  {f.classified_type}
+                  {t(`bugreport.type.${f.classified_type}`)}
                 </Tag>
               </div>
             ))

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -33,6 +33,7 @@ import {
   updateProjectPresets,
 } from '../api/projects'
 import AiPanel from '../components/AiPanel'
+import BugreportFileList from '../components/BugreportFileList'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import DirectoryFilePicker from '../components/DirectoryFilePicker'
 import FileUpload from '../components/FileUpload'
@@ -49,6 +50,7 @@ import { useLazyHciStream } from '../hooks/useLazyHciStream'
 import i18next from '../i18n/config'
 import type {
   AIConfig,
+  BugreportFileInfo,
   ContextDoc,
   FilterPreset,
   HighlightItem,
@@ -271,6 +273,10 @@ const AppContent: React.FC<{
 
   // Pending uploaded files — stored but not yet parsed (agent decides when to load)
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([])
+
+  // Bugreport extracted files — shown in BugreportFileList panel
+  const [bugreportFiles, setBugreportFiles] = useState<BugreportFileInfo[]>([])
+  const [bugreportExtractDir, setBugreportExtractDir] = useState<string>('')
 
   // Directory listing — populated by autoPath when isDirectory is detected
   const [directoryFiles, setDirectoryFiles] = useState<DirectoryFileInfo[]>([])
@@ -683,6 +689,8 @@ const AppContent: React.FC<{
       setFilteredHciEntries([])
       setDetectedFileType(null)
       setPendingFiles([])
+      setBugreportFiles([])
+      setBugreportExtractDir('')
       setFilters(DEFAULT_FILTERS)
       setActiveTab('log')
       setSelectedProjectId(projectId)
@@ -728,11 +736,27 @@ const AppContent: React.FC<{
       setTraceError(undefined)
       setTraceLoading(false)
       setPendingFiles([])
+      setBugreportFiles([])
+      setBugreportExtractDir('')
 
       try {
         const result = await uploadFiles(files)
-        if (result.files.length === 0) {
+        if (result.files.length === 0 && !result.bugreport_extracted) {
           void message.error(t('parseError'))
+          return
+        }
+
+        // ★ Bugreport branch — backend detected bugreport.zip and extracted files
+        if (
+          result.bugreport_extracted &&
+          result.bugreport_files &&
+          result.bugreport_files.length > 0
+        ) {
+          setBugreportFiles(result.bugreport_files)
+          setBugreportExtractDir(result.extract_dir || '')
+          setDetectedFileType('bugreport')
+          setActiveTab('log')
+          void message.success(t('fileUploaded'))
           return
         }
 
@@ -795,6 +819,49 @@ const AppContent: React.FC<{
       )
     },
     [loadSource, loadPcapSource, loadHciSource],
+  )
+
+  // Handle bugreport file click — route to appropriate tab based on classified_type
+  const handleBugreportFileClick = useCallback(
+    (file: BugreportFileInfo) => {
+      const fullPath = bugreportExtractDir
+        ? `${bugreportExtractDir.replace(/\\/g, '/').replace(/\/+$/, '')}/${file.path}`
+        : file.path
+      const displayName = file.original_name
+
+      switch (file.classified_type) {
+        case 'log':
+          setFilters(DEFAULT_FILTERS)
+          loadSource(fullPath, [displayName])
+          setActiveTab('log')
+          break
+        case 'pcap':
+          loadPcapSource(fullPath, [displayName], 'pcap')
+          setActiveTab('pcap')
+          break
+        case 'hci':
+          loadHciSource(fullPath, [displayName], 'hci')
+          setActiveTab('hci')
+          break
+        case 'trace':
+          // Trace files need to be parsed; switch to trace tab
+          setActiveTab('trace')
+          break
+        case 'anr':
+        case 'tombstone':
+        case 'other':
+          // Load as log — the AI agent can analyze these diagnostic files
+          setFilters(DEFAULT_FILTERS)
+          loadSource(fullPath, [displayName])
+          setActiveTab('log')
+          break
+      }
+
+      // Clear bugreport state after loading a file
+      setBugreportFiles([])
+      setBugreportExtractDir('')
+    },
+    [bugreportExtractDir, loadSource, loadPcapSource, loadHciSource],
   )
 
   // Local path handler — detects file vs directory, routes accordingly
@@ -899,7 +966,12 @@ const AppContent: React.FC<{
   )
 
   const showFileUpload =
-    !sourceRef && !traceResult && !pcapSourcePath && !hciSourcePath && pendingFiles.length === 0
+    !sourceRef &&
+    !traceResult &&
+    !pcapSourcePath &&
+    !hciSourcePath &&
+    pendingFiles.length === 0 &&
+    bugreportFiles.length === 0
 
   const isLoading = loadingFile || pcapLoading || hciLoading || traceLoading
   const errorMessage = fileError || pcapError || hciError || traceError
@@ -914,7 +986,8 @@ const AppContent: React.FC<{
     fileNames.length > 0 ||
     pcapFileNames.length > 0 ||
     hciFileNames.length > 0 ||
-    pendingFiles.length > 0
+    pendingFiles.length > 0 ||
+    bugreportFiles.length > 0
 
   const popoverFileInfo = hasLoadedFiles ? (
     <div style={{ marginBottom: 8 }}>
@@ -939,33 +1012,48 @@ const AppContent: React.FC<{
               </Tag>
             </div>
           ))
-        : loadedNames.map((name, idx) => (
-            <div
-              key={`${name}-${idx}`}
-              style={{ padding: '2px 0', display: 'flex', alignItems: 'center', gap: 6 }}
-            >
-              <FileOutlined style={{ fontSize: 12 }} />
-              <Typography.Text style={{ fontSize: 12 }} ellipsis title={name}>
-                {name}
-              </Typography.Text>
-              {detectedFileType && (
-                <Tag
-                  color={
-                    detectedFileType === 'pcap'
-                      ? 'blue'
-                      : detectedFileType === 'hci'
-                        ? 'purple'
-                        : detectedFileType === 'trace'
-                          ? 'orange'
-                          : 'green'
-                  }
-                  style={{ fontSize: 10, marginLeft: 4 }}
-                >
-                  {detectedFileType}
+        : bugreportFiles.length > 0
+          ? bugreportFiles.map((f, idx) => (
+              <div
+                key={`${f.original_name}-${idx}`}
+                style={{ padding: '2px 0', display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                <FileOutlined style={{ fontSize: 12 }} />
+                <Typography.Text style={{ fontSize: 12 }} ellipsis title={f.original_name}>
+                  {f.original_name}
+                </Typography.Text>
+                <Tag color="orange" style={{ fontSize: 10, marginLeft: 4 }}>
+                  {f.classified_type}
                 </Tag>
-              )}
-            </div>
-          ))}
+              </div>
+            ))
+          : loadedNames.map((name, idx) => (
+              <div
+                key={`${name}-${idx}`}
+                style={{ padding: '2px 0', display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                <FileOutlined style={{ fontSize: 12 }} />
+                <Typography.Text style={{ fontSize: 12 }} ellipsis title={name}>
+                  {name}
+                </Typography.Text>
+                {detectedFileType && (
+                  <Tag
+                    color={
+                      detectedFileType === 'pcap'
+                        ? 'blue'
+                        : detectedFileType === 'hci'
+                          ? 'purple'
+                          : detectedFileType === 'trace'
+                            ? 'orange'
+                            : 'green'
+                    }
+                    style={{ fontSize: 10, marginLeft: 4 }}
+                  >
+                    {detectedFileType}
+                  </Tag>
+                )}
+              </div>
+            ))}
     </div>
   ) : null
 
@@ -1246,6 +1334,11 @@ const AppContent: React.FC<{
                               loading={isLoading}
                               error={errorMessage}
                               fileNames={fileNames}
+                            />
+                          ) : bugreportFiles.length > 0 ? (
+                            <BugreportFileList
+                              files={bugreportFiles}
+                              onSelectFile={handleBugreportFileClick}
                             />
                           ) : pendingFiles.length > 0 ? (
                             <PendingFilesView

--- a/frontend/src/components/BugreportFileList.tsx
+++ b/frontend/src/components/BugreportFileList.tsx
@@ -103,6 +103,15 @@ const BugreportFileList: React.FC<BugreportFileListProps> = ({ files, onSelectFi
                     <List.Item
                       style={{ cursor: 'pointer', padding: '8px 12px' }}
                       onClick={() => onSelectFile(file)}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={file.original_name}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          onSelectFile(file)
+                        }
+                      }}
                     >
                       <div
                         style={{

--- a/frontend/src/components/BugreportFileList.tsx
+++ b/frontend/src/components/BugreportFileList.tsx
@@ -1,0 +1,150 @@
+import {
+  BugOutlined,
+  CodeOutlined,
+  FileTextOutlined,
+  FileUnknownOutlined,
+  GlobalOutlined,
+  LineChartOutlined,
+  WarningOutlined,
+  WifiOutlined,
+} from '@ant-design/icons'
+import { Card, Collapse, List, Tag, Typography } from 'antd'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { BugreportFileInfo } from '../types'
+
+const { Text } = Typography
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+const TYPE_META: Record<string, { icon: React.ReactNode; color: string; labelKey: string }> = {
+  log: { icon: <FileTextOutlined />, color: 'green', labelKey: 'bugreport.type.log' },
+  pcap: { icon: <GlobalOutlined />, color: 'blue', labelKey: 'bugreport.type.pcap' },
+  hci: { icon: <WifiOutlined />, color: 'purple', labelKey: 'bugreport.type.hci' },
+  trace: { icon: <LineChartOutlined />, color: 'orange', labelKey: 'bugreport.type.trace' },
+  anr: { icon: <WarningOutlined />, color: 'red', labelKey: 'bugreport.type.anr' },
+  tombstone: { icon: <BugOutlined />, color: 'volcano', labelKey: 'bugreport.type.tombstone' },
+  other: { icon: <FileUnknownOutlined />, color: 'default', labelKey: 'bugreport.type.other' },
+}
+
+const TYPE_ORDER = ['log', 'anr', 'tombstone', 'trace', 'pcap', 'hci', 'other'] as const
+
+interface BugreportFileListProps {
+  files: BugreportFileInfo[]
+  onSelectFile: (file: BugreportFileInfo) => void
+}
+
+const BugreportFileList: React.FC<BugreportFileListProps> = ({ files, onSelectFile }) => {
+  const { t } = useTranslation()
+
+  const grouped = useMemo(() => {
+    const map: Record<string, BugreportFileInfo[]> = {}
+    files.forEach((f) => {
+      const key = f.classified_type
+      if (!map[key]) map[key] = []
+      map[key].push(f)
+    })
+    return map
+  }, [files])
+
+  const sortedGroups = useMemo(() => {
+    return TYPE_ORDER.filter((type) => grouped[type] && grouped[type].length > 0)
+  }, [grouped])
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 16,
+        padding: 32,
+        overflow: 'auto',
+      }}
+    >
+      <Typography.Title level={5} style={{ margin: 0 }}>
+        <CodeOutlined style={{ marginRight: 8 }} />
+        {t('bugreport.title')}
+      </Typography.Title>
+      <Typography.Text type="secondary">
+        {t('bugreport.extracted', { count: files.length })}
+      </Typography.Text>
+
+      <Card size="small" style={{ width: '100%', maxWidth: 560 }}>
+        <Collapse
+          defaultActiveKey={sortedGroups}
+          size="small"
+          items={sortedGroups.map((type) => {
+            const groupFiles = grouped[type]
+            const meta = TYPE_META[type] || TYPE_META.other
+
+            return {
+              key: type,
+              label: (
+                <span>
+                  {meta.icon}
+                  <Text strong style={{ marginLeft: 6 }}>
+                    {t(meta.labelKey)}
+                  </Text>
+                  <Tag style={{ marginLeft: 8 }}>{groupFiles.length}</Tag>
+                </span>
+              ),
+              children: (
+                <List
+                  size="small"
+                  dataSource={groupFiles}
+                  renderItem={(file) => (
+                    <List.Item
+                      style={{ cursor: 'pointer', padding: '8px 12px' }}
+                      onClick={() => onSelectFile(file)}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          width: '100%',
+                        }}
+                      >
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <Text
+                            style={{ fontSize: 13, display: 'block' }}
+                            ellipsis
+                            title={file.original_name}
+                          >
+                            {file.original_name}
+                          </Text>
+                          <Text type="secondary" style={{ fontSize: 11 }}>
+                            {file.path}
+                          </Text>
+                        </div>
+                        <div
+                          style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}
+                        >
+                          <Tag color={meta.color} style={{ fontSize: 11 }}>
+                            {t(meta.labelKey)}
+                          </Tag>
+                          <Text type="secondary" style={{ fontSize: 11 }}>
+                            {formatFileSize(file.size)}
+                          </Text>
+                        </div>
+                      </div>
+                    </List.Item>
+                  )}
+                />
+              ),
+            }
+          })}
+        />
+      </Card>
+    </div>
+  )
+}
+
+export default BugreportFileList

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -314,5 +314,16 @@
   "clickToLoadFile": "Click a file to load and parse it",
   "loadFile": "Load",
   "directoryLoaded": "Directory loaded",
-  "directoryHint": "The AI assistant can explore files in this directory. Ask a question in the chat panel to get started."
+  "directoryHint": "The AI assistant can explore files in this directory. Ask a question in the chat panel to get started.",
+  "bugreport.title": "Bugreport Files",
+  "bugreport.extracted": "{{count}} files extracted",
+  "bugreport.expand": "Expand",
+  "bugreport.collapse": "Collapse",
+  "bugreport.type.log": "Log",
+  "bugreport.type.pcap": "Network Capture",
+  "bugreport.type.hci": "Bluetooth HCI",
+  "bugreport.type.trace": "Trace",
+  "bugreport.type.anr": "ANR",
+  "bugreport.type.tombstone": "Tombstone",
+  "bugreport.type.other": "Other"
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -314,5 +314,16 @@
   "clickToLoadFile": "点击文件以加载并解析",
   "loadFile": "加载",
   "directoryLoaded": "目录已加载",
-  "directoryHint": "AI 助手可以浏览此目录中的文件，在右侧聊天面板中提问即可开始分析。"
+  "directoryHint": "AI 助手可以浏览此目录中的文件，在右侧聊天面板中提问即可开始分析。",
+  "bugreport.title": "Bugreport 文件",
+  "bugreport.extracted": "已解压 {{count}} 个文件",
+  "bugreport.expand": "展开",
+  "bugreport.collapse": "收起",
+  "bugreport.type.log": "日志",
+  "bugreport.type.pcap": "网络抓包",
+  "bugreport.type.hci": "蓝牙 HCI",
+  "bugreport.type.trace": "Trace",
+  "bugreport.type.anr": "ANR",
+  "bugreport.type.tombstone": "Tombstone",
+  "bugreport.type.other": "其他"
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -152,6 +152,13 @@ export interface LocalFileRef {
   truncated: boolean
 }
 
+export interface BugreportFileInfo {
+  path: string
+  original_name: string
+  classified_type: 'log' | 'pcap' | 'hci' | 'trace' | 'anr' | 'tombstone' | 'other'
+  size: number
+}
+
 export interface ContextDoc {
   path: string
   content: string


### PR DESCRIPTION
## Summary

拖入 bugreport.zip → 自动解压 → 分类文件 → 按类型路由到对应分析 Tab

### Backend
- **bugreport_router.py**: is_bugreport_zip, extract_bugreport, classify_extracted_file
- 双层检测: 文件名匹配 + 内部结构检查
- 12 条文件分类规则 (log/pcap/hci/trace/anr/tombstone/other)
- Zip bomb 防护 (100:1 压缩比, 500MB 限制, 10000 文件上限)
- UnifiedUploadResponse 扩展 bugreport_files 元数据

### Frontend
- **BugreportFileList** 组件: 按类型分组、可折叠、i18n 支持
- App.tsx 集成: 检测 bugreport → 显示文件列表 → 点击路由到对应 Tab
- 类型: BugreportFileInfo, 18 个翻译 key (zh/en)

### Tests
- Backend: 12 新测试, 327 全量通过
- Frontend: tsc/prettier/eslint 零错误, vitest 0 回归

### Stats
10 files · +1279/−33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading bugreport ZIP files, with automatic extraction and grouping of the included logs and diagnostics.
  * Introduced a dedicated bugreport file view that lets you browse extracted items and open each one in the appropriate viewer.

* **Bug Fixes**
  * Improved handling of uploaded ZIP files so bugreports are recognized more reliably.
  * Added safer extraction behavior for compressed archives to reduce issues with invalid or unsafe files.

* **Documentation**
  * Added new localized labels and messages for the bugreport experience in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->